### PR TITLE
Add `--strict` to generate `z.object().strict()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ $ yarn test --watch
 And a playground inside `example`, buildable with the following command:
 
 ```sh
-$ yarn gen:example
+$ yarn gen:example --watch
 ```
 
 Last note, if you are updating `src/config.ts`, you need to run `yarn gen:config` to have generate the schemas of the config (`src/config.zod.ts`) (Yes, we are using the tool to build itself #inception)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,6 +82,11 @@ class TsToZod extends Command {
       default: false,
       description: "Skip the validation step (not recommended)",
     }),
+    strict: flags.boolean({
+      default: false,
+      description:
+        "Use `.strict()` in the generated schema to disallow unknown keys",
+    }),
     watch: flags.boolean({
       char: "w",
       default: false,
@@ -237,6 +242,9 @@ See more help with --help`,
     }
     if (typeof flags.keepComments === "boolean") {
       generateOptions.keepComments = flags.keepComments;
+    }
+    if (typeof flags.strict === "boolean") {
+      generateOptions.strict = flags.strict;
     }
 
     const {

--- a/src/core/generate.test.ts
+++ b/src/core/generate.test.ts
@@ -169,6 +169,7 @@ describe("generate", () => {
       nameFilter: (id) => id === "Superman",
       getSchemaName: (id) => id.toLowerCase(),
       keepComments: true,
+      strict: true,
     });
 
     it("should only generate superman schema", () => {
@@ -181,7 +182,7 @@ describe("generate", () => {
              * Name of superman
              */
             name: z.string()
-        });
+        }).strict();
         "
       `);
     });

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -31,6 +31,11 @@ export interface GenerateProps {
    * @default false
    */
   keepComments?: boolean;
+
+  /**
+   * Add `.strict()` to every `z.object()` (disallow unknown keys)
+   */
+  strict?: boolean;
 }
 
 /**
@@ -44,6 +49,7 @@ export function generate({
   nameFilter = () => true,
   getSchemaName = (id) => camel(id) + "Schema",
   keepComments = false,
+  strict = false,
 }: GenerateProps) {
   // Create a source file
   const sourceFile = ts.createSourceFile(
@@ -74,6 +80,7 @@ export function generate({
       sourceFile,
       varName,
       getDependencyName: getSchemaName,
+      strict,
     });
 
     return { typeName, varName, ...zodSchema };

--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -579,6 +579,31 @@ describe("generateZodSchema", () => {
       `"export const theLastTestSchema = zod.literal(true);"`
     );
   });
+
+  it("should generate a schema in strict mode", () => {
+    const source = `export interface FormalSuperman {
+     name: string;
+     age: number;
+     powers: Power[];
+     exposedSecrets: {
+       canFly: boolean;
+       isClark: boolean;
+       loveLois: boolean;
+     }
+   };`;
+    expect(generate(source, undefined, true)).toMatchInlineSnapshot(`
+      "export const formalSupermanSchema = z.object({
+          name: z.string(),
+          age: z.number(),
+          powers: z.array(powerSchema),
+          exposedSecrets: z.object({
+              canFly: z.boolean(),
+              isClark: z.boolean(),
+              loveLois: z.boolean()
+          }).strict()
+      }).strict();"
+    `);
+  });
 });
 
 /**
@@ -587,7 +612,7 @@ describe("generateZodSchema", () => {
  * @param sourceText Typescript interface or type
  * @returns Generated Zod schema
  */
-function generate(sourceText: string, z?: string) {
+function generate(sourceText: string, z?: string, strict?: boolean) {
   const sourceFile = ts.createSourceFile(
     "index.ts",
     sourceText,
@@ -609,6 +634,7 @@ function generate(sourceText: string, z?: string) {
     node: declaration,
     sourceFile,
     varName: zodConstName,
+    strict,
   });
   return ts
     .createPrinter({ newLine: ts.NewLineKind.LineFeed })


### PR DESCRIPTION
### Description

Add `--strict` to generate `z.object().strict()`

### Related issue

#8 

### Blocked by

https://github.com/colinhacks/zod/issues/390

### Todo

- [ ] Add `strict` flag to `example` and `config`
