### PR TITLE
Typo fix: Lenght -> Length

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ List of supported keywords:
 | ---------------------------------- | ----------------- | ---------------------------- |
 | `@minimum {number}`                | `@minimum 42`     | `z.number().min(42)`         |
 | `@maximum {number}`                | `@maximum 42`     | `z.number().max(42)`         |
-| `@minLenght {number}`              | `@minLenght 42`   | `z.string().min(42)`         |
-| `@maxLenght {number}`              | `@maxLenght 42`   | `z.string().min(42)`         |
+| `@minLength {number}`              | `@minLength 42`   | `z.string().min(42)`         |
+| `@maxLength {number}`              | `@maxLength 42`   | `z.string().min(42)`         |
 | `@format {"email"\|"uuid"\|"url"}` | `@format email`   | `z.string().email()`         |
 | `@pattern {regex}`                 | `@pattern ^hello` | `z.string().regex(/^hello/)` |
 
@@ -61,8 +61,8 @@ export interface HeroContact {
   /**
    * The name of the hero.
    *
-   * @minLenght 2
-   * @maxLenght 50
+   * @minLength 2
+   * @maxLength 50
    */
   name: string;
 
@@ -101,8 +101,8 @@ export const heroContactSchema = z.object({
   /**
    * The name of the hero.
    *
-   * @minLenght 2
-   * @maxLenght 50
+   * @minLength 2
+   * @maxLength 50
    */
   name: z.string().min(2).max(50),
 

--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -387,8 +387,8 @@ describe("generateZodSchema", () => {
       /**
        * The name of the hero.
        *
-       * @minLenght 2
-       * @maxLenght 50
+       * @minLength 2
+       * @maxLength 50
        */
       name: string;
     
@@ -425,8 +425,8 @@ describe("generateZodSchema", () => {
           /**
            * The name of the hero.
            *
-           * @minLenght 2
-           * @maxLenght 50
+           * @minLength 2
+           * @maxLength 50
            */
           name: z.string().min(2).max(50),
           /**

--- a/src/core/jsDocTags.ts
+++ b/src/core/jsDocTags.ts
@@ -21,8 +21,8 @@ export interface JSDocTags {
   minimum?: number;
   maximum?: number;
   default?: number | string | boolean;
-  minLenght?: number;
-  maxLenght?: number;
+  minLength?: number;
+  maxLength?: number;
   format?: typeof formats[-1];
   pattern?: string;
 }
@@ -37,8 +37,8 @@ function isJSDocTagKey(tagName: string): tagName is keyof JSDocTags {
     "minimum",
     "maximum",
     "default",
-    "minLenght",
-    "maxLenght",
+    "minLength",
+    "maxLength",
     "format",
     "pattern",
   ];
@@ -74,8 +74,8 @@ export function getJSDocTags(nodeType: ts.Node, sourceFile: ts.SourceFile) {
         switch (tagName) {
           case "minimum":
           case "maximum":
-          case "minLenght":
-          case "maxLenght":
+          case "minLength":
+          case "maxLength":
             if (tag.comment && !Number.isNaN(parseInt(tag.comment))) {
               jsDocTags[tagName] = parseInt(tag.comment);
             }
@@ -153,16 +153,16 @@ export function jsDocTagToZodProperties(
       expressions: [f.createNumericLiteral(jsDocTags.maximum)],
     });
   }
-  if (jsDocTags.minLenght !== undefined) {
+  if (jsDocTags.minLength !== undefined) {
     zodProperties.push({
       identifier: "min",
-      expressions: [f.createNumericLiteral(jsDocTags.minLenght)],
+      expressions: [f.createNumericLiteral(jsDocTags.minLength)],
     });
   }
-  if (jsDocTags.maxLenght !== undefined) {
+  if (jsDocTags.maxLength !== undefined) {
     zodProperties.push({
       identifier: "max",
-      expressions: [f.createNumericLiteral(jsDocTags.maxLenght)],
+      expressions: [f.createNumericLiteral(jsDocTags.maxLength)],
     });
   }
   if (jsDocTags.format) {


### PR DESCRIPTION
# Why

This fixes the following two typos:
- minLenght -> minLength
- maxLenght -> maxLength
