### PR TITLE
Docs fix: correct output from JSDoc `@default`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ export const heroContactSchema = z.object({
    *
    * @default true
    */
-  hasSuperPower: z.boolean().optional(),
+  hasSuperPower: z.boolean().default(true),
 
   /**
    * The age of the hero


### PR DESCRIPTION
# Why

Small correction on the README to clearly communicate what `@default` JSDoc directive does.
