### PR TITLE
Add tsutils to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "slash": "^3.0.0",
     "threads": "^1.6.3",
     "tslib": "^2.1.0",
+    "tsutils": "^3.21.0",
     "typescript": "^4.2.3",
     "zod": "^3.0.0-alpha.33"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4660,7 +4660,7 @@ tslib@^2.0.0, tslib@^2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
-tsutils@^3.17.1:
+tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==


### PR DESCRIPTION
# Why

It seemed easier to make a PR than to open an issue.  ts-to-zod [depends on tsutils directly to run](https://github.com/fabien0102/ts-to-zod/blob/main/src/core/jsDocTags.ts#L2), but it does not list tsutils in the dependencies of the project.  Because [the eslint TypeScript plugin does depend on tsutils](https://github.com/fabien0102/ts-to-zod/blob/main/yarn.lock#L779), this doesn't matter for ts-to-zod itself or any project using both ts-to-zod and that plugin, but any project not using eslint or the plugin will fail.  If you start a new, empty TypeScript project and add ts-to-zod (and nothing else) to it, running a command like `yarn ts-to-zod src/types/types.ts` will give:

```
Error: Cannot find module 'tsutils'
Require stack:
- /path/to/my-project/node_modules/ts-to-zod/lib/core/jsDocTags.js
- /path/to/my-project/node_modules/ts-to-zod/lib/core/generateZodSchema.js
- /path/to/my-project/node_modules/ts-to-zod/lib/core/generate.js
- /path/to/my-project/node_modules/ts-to-zod/lib/cli.js
- /path/to/my-project/node_modules/ts-to-zod/bin/run
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/path/to/my-project/node_modules/ts-to-zod/lib/core/jsDocTags.js:6:19)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/path/to/my-project/node_modules/ts-to-zod/lib/core/jsDocTags.js',
    '/path/to/my-project/node_modules/ts-to-zod/lib/core/generateZodSchema.js',
    '/path/to/my-project/node_modules/ts-to-zod/lib/core/generate.js',
    '/path/to/my-project/node_modules/ts-to-zod/lib/cli.js',
    '/path/to/my-project/node_modules/ts-to-zod/bin/run'
  ]
}
error Command failed with exit code 1.
```

The fix is just to add tsutils to the dependencies of the project.
