### PR TITLE
feat: Add `never` support

### DIFF
--- a/example/heros.ts
+++ b/example/heros.ts
@@ -15,6 +15,7 @@ export interface Villain {
   name: string;
   powers: string[];
   friends: Villain[];
+  canBeTrusted: never;
 }
 
 export interface EvilPlan {

--- a/example/heros.zod.ts
+++ b/example/heros.zod.ts
@@ -24,6 +24,7 @@ export const villainSchema: z.ZodSchema<Villain> = z.lazy(() =>
     name: z.string(),
     powers: z.array(z.string()),
     friends: z.array(villainSchema),
+    canBeTrusted: z.never(),
   })
 );
 

--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -88,6 +88,13 @@ describe("generateZodSchema", () => {
     );
   });
 
+  it("should generate a never", () => {
+    const source = `export type CanBeatZod = never;`;
+    expect(generate(source)).toMatchInlineSnapshot(
+      `"export const canBeatZodSchema = z.never();"`
+    );
+  });
+
   it("should generate an array schema (T[] notation)", () => {
     const source = `export type Villains = string[];`;
     expect(generate(source)).toMatchInlineSnapshot(

--- a/src/core/generateZodSchema.ts
+++ b/src/core/generateZodSchema.ts
@@ -574,6 +574,8 @@ function buildZodPrimitive({
       return buildZodSchema(z, "bigint", [], zodProperties);
     case ts.SyntaxKind.VoidKeyword:
       return buildZodSchema(z, "void", [], zodProperties);
+    case ts.SyntaxKind.NeverKeyword:
+      return buildZodSchema(z, "never", [], zodProperties);
   }
 
   console.warn(


### PR DESCRIPTION
# Why

The `never` keyword was forgot and could be translated by `z.never()`

## Related issue

#24
