### PR TITLE
fix: Fix typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "threads": "^1.6.3",
     "tslib": "^2.1.0",
     "tsutils": "^3.21.0",
-    "typescript": "^4.2.3",
-    "zod": "^3.0.2"
+    "typescript": "4.2.3",
+    "zod": "^3.1.0"
   },
   "devDependencies": {
     "@types/async": "^3.2.6",

--- a/src/core/jsDocTags.ts
+++ b/src/core/jsDocTags.ts
@@ -70,7 +70,7 @@ export function getJSDocTags(nodeType: ts.Node, sourceFile: ts.SourceFile) {
     jsDoc.forEach((doc) => {
       (doc.tags || []).forEach((tag) => {
         const tagName = tag.tagName.escapedText.toString();
-        if (!isJSDocTagKey(tagName)) return;
+        if (!isJSDocTagKey(tagName) || typeof tag.comment !== "string") return;
         switch (tagName) {
           case "minimum":
           case "maximum":

--- a/yarn.lock
+++ b/yarn.lock
@@ -4725,7 +4725,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.2.3:
+typescript@4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
@@ -5028,7 +5028,7 @@ yn@3.1.1:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-zod@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.0.2.tgz#0d8f0adbc7569e1a3c67b2cc788f81a55dc8a403"
-  integrity sha512-a+9VrxBi5CWBFq2LO5aNgbAaIRzPpBLbH4qGjSFeKd/ClLAXZq1dNFLTe9N1VDUBKxqXgHVkMlyp5MtSJylJww==
+zod@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.1.0.tgz#b9b6c0f949f9b54eb2c32cbbe81e9d0f24a143d8"
+  integrity sha512-qS0an8oo9EvVLVqIVxMZrQrfR2pVwBtlPp+BzTB/F19IyPTRaLLoFfdXRzgh626pxFR1efuTWV8bPoEE58KwqA==


### PR DESCRIPTION
# Why

Apparently newest version of typescript are breaking some type comparisons, also this is more safe to have a stable version of typescript for this project (since we are using the compiler API).

## Related issue

#27 