### PR TITLE
Fixes #36 | Allows for single value unions

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -168,6 +168,13 @@ describe("generateZodSchema", () => {
     );
   });
 
+  it("should generate a literal schema for a single union", () => {
+    const source = `export type Identity = | "superman";`;
+    expect(generate(source)).toMatchInlineSnapshot(
+      `"export const identitySchema = z.literal(\\"superman\\");"`
+    );
+  });
+
   it("should generate two joined schemas", () => {
     const source = `export type SupermanWithWeakness = Superman & { weakness: Kryptonite };`;
     expect(generate(source)).toMatchInlineSnapshot(`

--- a/src/core/generateZodSchema.ts
+++ b/src/core/generateZodSchema.ts
@@ -394,6 +394,11 @@ function buildZodPrimitive({
         getDependencyName,
       })
     );
+    // type A = | 'b' is a valid typescript definintion
+    // Zod does not allow `z.union(['b']), so we have to return just the value
+    if (values.length === 1) {
+      return values[0];
+    }
     return buildZodSchema(
       z,
       "union",


### PR DESCRIPTION
# Why

Fixes #36.  Handles single value unions how typescript handles them.
