### PR TITLE
feat: add support for  `z.set`

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -221,6 +221,13 @@ describe("generateZodSchema", () => {
     );
   });
 
+  it("should generate a set schema", () => {
+    const source = `export type EnemiesPowers = Set<string>;`;
+    expect(generate(source)).toMatchInlineSnapshot(
+      `"export const enemiesPowersSchema = z.set(z.string());"`
+    );
+  });
+
   it("should generate a function schema", () => {
     const source = `export type KillSuperman = (withKryptonite: boolean, method: string) => Promise<boolean>;`;
     expect(generate(source)).toMatchInlineSnapshot(

--- a/src/core/generateZodSchema.ts
+++ b/src/core/generateZodSchema.ts
@@ -366,6 +366,28 @@ function buildZodPrimitive({
       return buildZodSchema(z, "date", [], zodProperties);
     }
 
+    // Deal with `Set<>` syntax
+    if (identifierName === "Set" && typeNode.typeArguments) {
+      return buildZodSchema(
+        z,
+        "set",
+        typeNode.typeArguments.map((i) =>
+          buildZodPrimitive({
+            z,
+            typeNode: i,
+            isOptional: false,
+            jsDocTags,
+            sourceFile,
+            dependencies,
+            getDependencyName,
+            skipParseJSDoc,
+            maybeConfig,
+          })
+        ),
+        zodProperties
+      );
+    }
+
     // Deal with `Promise<>` syntax
     if (identifierName === "Promise" && typeNode.typeArguments) {
       return buildZodSchema(


### PR DESCRIPTION
# Why

Transform `Set<string>` to `z.set(z.string())`
