### PR TITLE
Add missing dependency on @oclif/errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@oclif/command": "^1.8.6",
     "@oclif/config": "^1.17.1",
+    "@oclif/errors": "^1.3",
     "@oclif/plugin-help": "^3.2.7",
     "@typescript/vfs": "^1.3.5",
     "async": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1675,6 +1675,17 @@
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+"@oclif/errors@^1.3":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.6.tgz#e8fe1fc12346cb77c4f274e26891964f5175f75d"
+  integrity sha512-fYaU4aDceETd89KXP+3cLyg9EHZsLD3RxF2IU9yxahhBpspWjkWi3Dy3bTgcwZ3V47BgxQaGapzJWDM33XIVDQ==
+  dependencies:
+    clean-stack "^3.0.0"
+    fs-extra "^8.1"
+    indent-string "^4.0.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 "@oclif/errors@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.5.tgz#a1e9694dbeccab10fe2fe15acb7113991bed636c"
@@ -4952,6 +4963,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# Why

In cli.ts, `@oclif/errors` is imported, but it is not specified in the package dependencies. This makes the require call ambiguous and unsound, and produces this error when used in a project using yarn (with pnp):

```
Error: ts-to-zod tried to access @oclif/errors, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @oclif/errors
Required by: ts-to-zod@npm:2.0.1
```

I assume the package was hoisted from the other `@oclif/*` packages, which can cause problems.