### PR TITLE
feat: support standard built-in objects

### DIFF
--- a/src/core/const.ts
+++ b/src/core/const.ts
@@ -1,0 +1,75 @@
+// Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
+export const standardBuiltInObjects = [
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#fundamental_objects
+  "Object",
+  "Function",
+  "Boolean",
+  "Symbol",
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#error_objects
+  "Error",
+  "AggregateError",
+  "EvalError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "TypeError",
+  "URIError",
+  // "InternalError",
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#numbers_and_dates
+  "Number",
+  "BigInt",
+  "Math",
+  // "Date",
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#indexed_collections
+  // "Array",
+  "Int8Array",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int16Array",
+  "Uint16Array",
+  "Int32Array",
+  "Uint32Array",
+  "BigInt64Array",
+  "BigUint64Array",
+  "Float32Array",
+  "Float64Array",
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#keyed_collections
+  "Map",
+  "Set",
+  "WeakMap",
+  "WeakSet",
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#structured_data
+  "ArrayBuffer",
+  "SharedArrayBuffer",
+  "DataView",
+  "Atomics",
+  "JSON",
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#managing_memory
+  "WeakRef",
+  "FinalizationRegistry",
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#control_abstraction_objects
+  "Promise",
+  "GeneratorFunction",
+  "AsyncGeneratorFunction",
+  "Generator",
+  "AsyncGenerator",
+  "AsyncFunction",
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#reflection
+  "Reflect",
+  "Proxy",
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#internationalization
+  // "Intl",
+  // "Intl.Collator",
+  // "Intl.DateTimeFormat",
+  // "Intl.DisplayNames",
+  // "Intl.ListFormat",
+  // "Intl.Locale",
+  // "Intl.NumberFormat",
+  // "Intl.PluralRules",
+  // "Intl.RelativeTimeFormat",
+  // "Intl.Segmenter",
+];
+
+export const standardBuiltInObjectVarNames = standardBuiltInObjects.map(
+  (n) => n[0].toLocaleLowerCase() + n.substring(1) + "Schema"
+);


### PR DESCRIPTION
# Why

Browser and Node.js both provide many standard built-in objects such as `Error` `Int8Array` `BigInt` etc.

Before this PR, if types are using these built-in objects, `ts-to-zod` will fail with `missing dependencies`, this PR support built-in objects by using Zod's `z.instanceof` method.

For example:
```ts
export interface Person {
  photo?: Uint8Array | null;
}
```

will generate:
```ts
const uint8ArraySchema = z.instanceof(Uint8Array);

export const personSchema = z.object({
  photo: uint8ArraySchema.optional().nullable(),
});
```

The list of standard built-in objects is from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
