### PR TITLE
Adding JSDoc tag `useStrict` to output `strict()` modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Other JSDoc tags are available:
 | JSDoc keyword      | JSDoc Example | Description                               | Generated Zod            |
 | ------------------ | ------------- | ----------------------------------------- | ------------------------ |
 | `@default {value}` | `@default 42` | Sets a default value for the property     | `z.number().default(42)` |
-| `@useStrict`       | `@useStrict`  | Adds the `strict()` modifier to an object | `z.object().strict()`    |
+| `@strict`          | `@strict`     | Adds the `strict()` modifier to an object | `z.object().strict()`    |
 
 ## Advanced configuration
 

--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -847,9 +847,9 @@ describe("generateZodSchema", () => {
     `);
   });
 
-  it("should generate add strict() validation when @useStrict is used", () => {
+  it("should generate add strict() validation when @strict is used", () => {
     const source = `/**
-    * @useStrict
+    * @strict
     */
     export type Superman = {
       name: "superman";
@@ -859,7 +859,7 @@ describe("generateZodSchema", () => {
     };`;
     expect(generate(source)).toMatchInlineSnapshot(`
        "/**
-           * @useStrict
+           * @strict
            */
        export const supermanSchema = z.object({
            name: z.literal(\\"superman\\"),
@@ -870,9 +870,9 @@ describe("generateZodSchema", () => {
      `);
   });
 
-  it("should generate add strict() validation when @useStrict is used on subtype", () => {
+  it("should generate add strict() validation when @strict is used on subtype", () => {
     const source = `export interface A {
-      /** @useStrict */
+      /** @strict */
       a: {
         b: number
       }
@@ -880,7 +880,7 @@ describe("generateZodSchema", () => {
 
     expect(generate(source)).toMatchInlineSnapshot(`
       "export const aSchema = z.object({
-          /** @useStrict */
+          /** @strict */
           a: z.object({
               b: z.number()
           }).strict()

--- a/src/core/jsDocTags.ts
+++ b/src/core/jsDocTags.ts
@@ -30,7 +30,7 @@ export interface JSDocTags {
   maxLength?: TagWithError<number>;
   format?: TagWithError<typeof formats[-1]>;
   pattern?: string;
-  useStrict?: boolean;
+  strict?: boolean;
 }
 
 /**
@@ -100,7 +100,7 @@ export function getJSDocTags(nodeType: ts.Node, sourceFile: ts.SourceFile) {
         const tagName = tag.tagName.escapedText.toString();
 
         // Handling "unary operator" tag first (no tag.comment part needed)
-        if (tagName === "useStrict") {
+        if (tagName === "strict") {
           jsDocTags[tagName] = true;
           return;
         }
@@ -263,7 +263,7 @@ export function jsDocTagToZodProperties(
           : [f.createStringLiteral(jsDocTags.default)],
     });
   }
-  if (jsDocTags.useStrict) {
+  if (jsDocTags.strict) {
     zodProperties.push({ identifier: "strict" });
   }
 


### PR DESCRIPTION
# Why

This solves https://github.com/fabien0102/ts-to-zod/issues/78 using a new `@useStrict` JSDoc tag key.

```
/** @useStrict */
export interface A {
    a: string
}
``` 
will generate the following: 
```
export const aSchema = z.object({
    a: z.string()
}).strict();
```

and

```
export interface A {
    /** @useStrict */
    a: {
        b: number
    }
}
```
will generate 
```
export const aSchema = z.object({
    a: z.object({
        b: z.number()
    }).strict()
});
```