### PR TITLE
[Fix] strict() modifier should come before optional/nullable

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -870,7 +870,7 @@ describe("generateZodSchema", () => {
      `);
   });
 
-  it("should generate add strict() validation when @strict is used on subtype", () => {
+  it("should add strict() validation when @strict is used on subtype", () => {
     const source = `export interface A {
       /** @strict */
       a: {
@@ -884,6 +884,42 @@ describe("generateZodSchema", () => {
           a: z.object({
               b: z.number()
           }).strict()
+      });"
+    `);
+  });
+
+  it("should add strict() before optional() validation when @strict is used on optional subtype", () => {
+    const source = `export interface A {
+      /** @strict */
+      a?: {
+        b: number
+      }
+    }`;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "export const aSchema = z.object({
+          /** @strict */
+          a: z.object({
+              b: z.number()
+          }).strict().optional()
+      });"
+    `);
+  });
+
+  it("should add strict() before nullable() validation when @strict is used on nullable subtype", () => {
+    const source = `export interface A {
+      /** @strict */
+      a: {
+        b: number
+      } | null
+    }`;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "export const aSchema = z.object({
+          /** @strict */
+          a: z.object({
+              b: z.number()
+          }).strict().nullable()
       });"
     `);
   });

--- a/src/core/jsDocTags.ts
+++ b/src/core/jsDocTags.ts
@@ -230,6 +230,10 @@ export function jsDocTagToZodProperties(
       expressions: [f.createRegularExpressionLiteral(`/${jsDocTags.pattern}/`)],
     });
   }
+  // strict() must be before optional() and nullable()
+  if (jsDocTags.strict) {
+    zodProperties.push({ identifier: "strict" });
+  }
   if (isOptional) {
     zodProperties.push({
       identifier: "optional",
@@ -262,9 +266,6 @@ export function jsDocTagToZodProperties(
           ? [f.createNumericLiteral(jsDocTags.default)]
           : [f.createStringLiteral(jsDocTags.default)],
     });
-  }
-  if (jsDocTags.strict) {
-    zodProperties.push({ identifier: "strict" });
   }
 
   return zodProperties;


### PR DESCRIPTION
# Why

The `strict()` modifier, when applied to a subtype (e.g. an interface property), should be applied before `optional()` and `nullable()` (otherwise Zod will raise type validation errors).

This PR fixes it. 