### PR TITLE
Refactoring of getExtractedTypeNames

### DIFF
--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -95,11 +95,7 @@ export function generate({
       if (!jsDocTagFilter(tags)) return;
       if (!nameFilter(node.name.text)) return;
 
-      const typeNames = getExtractedTypeNames(
-        node,
-        sourceFile,
-        typeNameMapping
-      );
+      const typeNames = getExtractedTypeNames(node, sourceFile);
       typeNames.forEach((typeName) => {
         typesNeedToBeExtracted.add(typeName);
       });

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -89,10 +89,10 @@ describe("traverseTypes", () => {
 
     it("should extract union type reference", () => {
       const source = `
-            export interface Person {
-                id: number,
-                t: SuperHero | Villain
-            }`;
+        export interface Person {
+            id: number,
+            t: SuperHero | Villain
+        }`;
 
       const result = extractNames(source);
       expect(result).toEqual(["Person", "SuperHero", "Villain"]);
@@ -100,10 +100,10 @@ describe("traverseTypes", () => {
 
     it("should extract intersection type reference", () => {
       const source = `
-              export interface Person {
-                  id: number,
-                  t: SuperHero & Villain
-              }`;
+        export interface Person {
+            id: number,
+            t: SuperHero & Villain
+        }`;
 
       const result = extractNames(source);
       expect(result).toEqual(["Person", "SuperHero", "Villain"]);
@@ -111,10 +111,10 @@ describe("traverseTypes", () => {
 
     it("should extract intersection type reference with type literal", () => {
       const source = `
-                export interface Person {
-                    id: number,
-                    t: SuperHero & { counter: Villain }
-                }`;
+        export interface Person {
+            id: number,
+            t: SuperHero & { counter: Villain }
+        }`;
 
       const result = extractNames(source);
       expect(result).toEqual(["Person", "SuperHero", "Villain"]);

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -1,0 +1,91 @@
+import ts from "typescript";
+import { getExtractedTypeNames } from "./traverseTypes";
+import { findNode } from "./findNode";
+
+describe("traverseTypes", () => {
+  describe("getExtractedTypeNames", () => {
+    it("should find only itself", () => {
+      const testCases = [
+        `
+        export type Superhero = {
+            id: number, 
+            name: string
+          };
+        `,
+        `
+        export interface Superhero = {
+            id: number, 
+            name: string
+          };
+        `,
+        `
+        export enum Superhero = {
+            Superman = "superman",
+            ClarkKent = "clark_kent",
+          };
+        `,
+      ];
+
+      testCases.forEach((source: string) => {
+        const result = extractNames(source);
+        expect(result).toEqual(["Superhero"]);
+      });
+    });
+
+    it("should extract type referenced in property", () => {
+      const source = `
+        export interface Superhero {
+            id: number,
+            person: Person,
+        }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Superhero", "Person"]);
+    });
+
+    it("should extract type referenced in extend clause", () => {
+      const source = `
+          export interface Superhero extends Person {
+              id: number,
+          }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Superhero", "Person"]);
+    });
+
+    it("should extract type referenced in multiple extend clauses", () => {
+      const source = `
+            export interface Superhero extends Person, Person2 {
+                id: number,
+            }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Superhero", "Person", "Person2"]);
+    });
+  });
+});
+
+function extractNames(sourceText: string) {
+  const sourceFile = ts.createSourceFile(
+    "index.ts",
+    sourceText,
+    ts.ScriptTarget.Latest
+  );
+  const declaration = findNode(
+    sourceFile,
+    (
+      node
+    ): node is
+      | ts.InterfaceDeclaration
+      | ts.TypeAliasDeclaration
+      | ts.EnumDeclaration =>
+      ts.isInterfaceDeclaration(node) ||
+      ts.isTypeAliasDeclaration(node) ||
+      ts.isEnumDeclaration(node)
+  );
+  if (!declaration) {
+    throw new Error("No `type` or `interface` found!");
+  }
+
+  return getExtractedTypeNames(declaration, sourceFile);
+}

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -62,6 +62,18 @@ describe("traverseTypes", () => {
       const result = extractNames(source);
       expect(result).toEqual(["Superhero", "Person", "Person2"]);
     });
+
+    it("should extract type referenced in property as array", () => {
+      const source = `
+            export interface Superhero {
+                id: number,
+                sidekicks: Person[],
+            }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Superhero", "Person"]);
+    });
+
   });
 });
 

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -74,6 +74,18 @@ describe("traverseTypes", () => {
       expect(result).toEqual(["Superhero", "Person"]);
     });
 
+    it("should extract nested type reference", () => {
+      const source = `
+          export interface Superhero {
+              id: number,
+              person: {
+                type: Person,
+              }
+          }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Superhero", "Person"]);
+    });
   });
 });
 

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -86,6 +86,39 @@ describe("traverseTypes", () => {
       const result = extractNames(source);
       expect(result).toEqual(["Superhero", "Person"]);
     });
+
+    it("should extract union type reference", () => {
+      const source = `
+            export interface Person {
+                id: number,
+                t: SuperHero | Villain
+            }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "SuperHero", "Villain"]);
+    });
+
+    it("should extract intersection type reference", () => {
+      const source = `
+              export interface Person {
+                  id: number,
+                  t: SuperHero & Villain
+              }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "SuperHero", "Villain"]);
+    });
+
+    it("should extract intersection type reference with type literal", () => {
+      const source = `
+                export interface Person {
+                    id: number,
+                    t: SuperHero & { counter: Villain }
+                }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "SuperHero", "Villain"]);
+    });
   });
 });
 

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -33,7 +33,7 @@ export function getExtractedTypeNames(
     });
   }
 
-  node.forEachChild((child) => {
+  const visitorExtract = (child: ts.Node) => {
     const childNode = child as ts.PropertySignature;
     if (!ts.isPropertySignature(childNode)) {
       return;
@@ -47,9 +47,13 @@ export function getExtractedTypeNames(
         ts.isTypeNode(childNode.type.elementType)
       ) {
         referenceTypeNames.add(childNode.type.elementType.getText(sourceFile));
+      } else if (ts.isTypeLiteralNode(childNode.type)) {
+        childNode.type.forEachChild(visitorExtract);
       }
     }
-  });
+  };
+
+  node.forEachChild(visitorExtract);
 
   return Array.from(referenceTypeNames);
 }

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -1,10 +1,9 @@
 import ts from "typescript";
 
-export type TypeNode = (
+export type TypeNode =
   | ts.InterfaceDeclaration
   | ts.TypeAliasDeclaration
-  | ts.EnumDeclaration
-) & { visited?: boolean };
+  | ts.EnumDeclaration;
 
 export function isTypeNode(node: ts.Node): node is TypeNode {
   return (
@@ -17,12 +16,8 @@ export function isTypeNode(node: ts.Node): node is TypeNode {
 export function getExtractedTypeNames(
   node: TypeNode,
   sourceFile: ts.SourceFile
-) {
-  const referenceTypeNames: string[] = [];
-
-  if (node.visited) {
-    return;
-  }
+): string[] {
+  const referenceTypeNames: string[] = [node.name.text];
 
   const heritageClauses = (node as ts.InterfaceDeclaration).heritageClauses;
 
@@ -48,5 +43,5 @@ export function getExtractedTypeNames(
     }
   });
 
-  return [node.name.text, ...referenceTypeNames];
+  return referenceTypeNames;
 }

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -16,56 +16,37 @@ export function isTypeNode(node: ts.Node): node is TypeNode {
 
 export function getExtractedTypeNames(
   node: TypeNode,
-  sourceFile: ts.SourceFile,
-  typeNameMapping: Map<string, TypeNode>
+  sourceFile: ts.SourceFile
 ) {
   const referenceTypeNames: string[] = [];
 
-  const recursiveExtract = (node: TypeNode) => {
-    if (node.visited) {
+  if (node.visited) {
+    return;
+  }
+
+  const heritageClauses = (node as ts.InterfaceDeclaration).heritageClauses;
+
+  if (heritageClauses) {
+    heritageClauses.forEach((clause) => {
+      const extensionTypes = clause.types;
+      extensionTypes.forEach((extensionTypeNode) => {
+        const typeName = extensionTypeNode.expression.getText(sourceFile);
+
+        referenceTypeNames.push(typeName);
+      });
+    });
+  }
+
+  node.forEachChild((child) => {
+    const childNode = child as ts.PropertySignature;
+    if (childNode.kind !== ts.SyntaxKind.PropertySignature) {
       return;
     }
 
-    const heritageClauses = (node as ts.InterfaceDeclaration).heritageClauses;
-
-    if (heritageClauses) {
-      heritageClauses.forEach((clause) => {
-        const extensionTypes = clause.types;
-        extensionTypes.forEach((extensionTypeNode) => {
-          const typeName = extensionTypeNode.expression.getText(sourceFile);
-          const typeNode = typeNameMapping.get(typeName);
-
-          referenceTypeNames.push(typeName);
-
-          if (typeNode) {
-            typeNode.visited = true;
-            recursiveExtract(typeNode);
-          }
-        });
-      });
+    if (childNode.type?.kind === ts.SyntaxKind.TypeReference) {
+      referenceTypeNames.push(childNode.type.getText(sourceFile));
     }
+  });
 
-    node.forEachChild((child) => {
-      const childNode = child as ts.PropertySignature;
-      if (childNode.kind !== ts.SyntaxKind.PropertySignature) {
-        return;
-      }
-
-      if (childNode.type?.kind === ts.SyntaxKind.TypeReference) {
-        const typeNode = typeNameMapping.get(
-          childNode.type.getText(sourceFile)
-        );
-
-        referenceTypeNames.push(childNode.type.getText(sourceFile));
-
-        if (typeNode) {
-          typeNode.visited = true;
-          recursiveExtract(typeNode);
-        }
-      }
-    });
-  };
-
-  recursiveExtract(node);
   return [node.name.text, ...referenceTypeNames];
 }

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -39,8 +39,15 @@ export function getExtractedTypeNames(
       return;
     }
 
-    if (childNode.type && ts.isTypeReferenceNode(childNode.type)) {
-      referenceTypeNames.add(childNode.type.getText(sourceFile));
+    if (childNode.type) {
+      if (ts.isTypeReferenceNode(childNode.type)) {
+        referenceTypeNames.add(childNode.type.getText(sourceFile));
+      } else if (
+        ts.isArrayTypeNode(childNode.type) &&
+        ts.isTypeNode(childNode.type.elementType)
+      ) {
+        referenceTypeNames.add(childNode.type.elementType.getText(sourceFile));
+      }
     }
   });
 

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -17,7 +17,8 @@ export function getExtractedTypeNames(
   node: TypeNode,
   sourceFile: ts.SourceFile
 ): string[] {
-  const referenceTypeNames: string[] = [node.name.text];
+  const referenceTypeNames = new Set<string>();
+  referenceTypeNames.add(node.name.text);
 
   const heritageClauses = (node as ts.InterfaceDeclaration).heritageClauses;
 
@@ -27,7 +28,7 @@ export function getExtractedTypeNames(
       extensionTypes.forEach((extensionTypeNode) => {
         const typeName = extensionTypeNode.expression.getText(sourceFile);
 
-        referenceTypeNames.push(typeName);
+        referenceTypeNames.add(typeName);
       });
     });
   }
@@ -39,9 +40,9 @@ export function getExtractedTypeNames(
     }
 
     if (childNode.type && ts.isTypeReferenceNode(childNode.type)) {
-      referenceTypeNames.push(childNode.type.getText(sourceFile));
+      referenceTypeNames.add(childNode.type.getText(sourceFile));
     }
   });
 
-  return referenceTypeNames;
+  return Array.from(referenceTypeNames);
 }

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -39,11 +39,11 @@ export function getExtractedTypeNames(
 
   node.forEachChild((child) => {
     const childNode = child as ts.PropertySignature;
-    if (childNode.kind !== ts.SyntaxKind.PropertySignature) {
+    if (!ts.isPropertySignature(childNode)) {
       return;
     }
 
-    if (childNode.type?.kind === ts.SyntaxKind.TypeReference) {
+    if (childNode.type && ts.isTypeReferenceNode(childNode.type)) {
       referenceTypeNames.push(childNode.type.getText(sourceFile));
     }
   });

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -49,6 +49,15 @@ export function getExtractedTypeNames(
         referenceTypeNames.add(childNode.type.elementType.getText(sourceFile));
       } else if (ts.isTypeLiteralNode(childNode.type)) {
         childNode.type.forEachChild(visitorExtract);
+      } else if (
+        ts.isIntersectionTypeNode(childNode.type) ||
+        ts.isUnionTypeNode(childNode.type)
+      ) {
+        childNode.type.types.forEach((typeNode: ts.TypeNode) => {
+          if (ts.isTypeReferenceNode(typeNode)) {
+            referenceTypeNames.add(typeNode.getText(sourceFile));
+          } else typeNode.forEachChild(visitorExtract);
+        });
       }
     }
   };


### PR DESCRIPTION
# Why

When working on another PR (https://github.com/fabien0102/ts-to-zod/pull/135), I found out that the current `getExtractedTypeNames` actually works, for most cases, "by mistake" because it's always run for all nodes in the file and types are always referenced in the file (so an error in one call would "self-heal" in a subsequent one).

I added some tests (see commit https://github.com/tvillaren/ts-to-zod/commit/9a2294ad0d1066c5722b4bc390f1befcb8870c63 for the tests added to the original file, some not passing) and refactored the method, everything is still green.
