### PR TITLE
[Fix] Add support for ParenthesisTypeNodes

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -1023,6 +1023,23 @@ describe("generateZodSchema", () => {
     `);
   });
 
+  it("should handle parenthesis type nodes", () => {
+    const source = `export interface A {
+      a: (number) | string | null;
+      b: (string)
+      c: (number | string)
+    }
+    `;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "export const aSchema = z.object({
+          a: z.union([z.number(), z.string()]).nullable(),
+          b: z.string(),
+          c: z.union([z.number(), z.string()])
+      });"
+    `);
+  });
+
   it("should allow nullable on optional union properties", () => {
     const source = `export interface A {
       a?: number | string | null;

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -119,6 +119,28 @@ describe("traverseTypes", () => {
       const result = extractNames(source);
       expect(result).toEqual(["Person", "SuperHero", "Villain"]);
     });
+
+    it("should extract types between parenthesis", () => {
+      const source = `
+        export interface Person {
+            id: number,
+            t: (SuperHero)
+        }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "SuperHero"]);
+    });
+
+    it("should extract union types between parenthesis", () => {
+      const source = `
+        export interface Person {
+            id: number,
+            t: (SuperHero | Villain)
+        }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "SuperHero", "Villain"]);
+    });
   });
 });
 

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -40,20 +40,26 @@ export function getExtractedTypeNames(
     }
 
     if (childNode.type) {
-      if (ts.isTypeReferenceNode(childNode.type)) {
-        referenceTypeNames.add(childNode.type.getText(sourceFile));
+      let typeNode = childNode.type;
+
+      if (ts.isParenthesizedTypeNode(childNode.type)) {
+        typeNode = childNode.type.type;
+      }
+
+      if (ts.isTypeReferenceNode(typeNode)) {
+        referenceTypeNames.add(typeNode.getText(sourceFile));
       } else if (
-        ts.isArrayTypeNode(childNode.type) &&
-        ts.isTypeNode(childNode.type.elementType)
+        ts.isArrayTypeNode(typeNode) &&
+        ts.isTypeNode(typeNode.elementType)
       ) {
-        referenceTypeNames.add(childNode.type.elementType.getText(sourceFile));
-      } else if (ts.isTypeLiteralNode(childNode.type)) {
-        childNode.type.forEachChild(visitorExtract);
+        referenceTypeNames.add(typeNode.elementType.getText(sourceFile));
+      } else if (ts.isTypeLiteralNode(typeNode)) {
+        typeNode.forEachChild(visitorExtract);
       } else if (
-        ts.isIntersectionTypeNode(childNode.type) ||
-        ts.isUnionTypeNode(childNode.type)
+        ts.isIntersectionTypeNode(typeNode) ||
+        ts.isUnionTypeNode(typeNode)
       ) {
-        childNode.type.types.forEach((typeNode: ts.TypeNode) => {
+        typeNode.types.forEach((typeNode: ts.TypeNode) => {
           if (ts.isTypeReferenceNode(typeNode)) {
             referenceTypeNames.add(typeNode.getText(sourceFile));
           } else typeNode.forEachChild(visitorExtract);


### PR DESCRIPTION
# Why

As reported by @anthony-dandrea in https://github.com/fabien0102/ts-to-zod/pull/148#issuecomment-1664231249, it doesn't work when there are parenthesis around the types:

```ts
// DoesntWork.ts
import type { BoolValue } from "google/protobuf/BoolValue";
export interface Broken {
  bool: (BoolValue | null);
}

// DoesWork.ts
import type { BoolValue } from "google/protobuf/BoolValue";
export interface Works {
  bool: BoolValue | null;
}

// google/protobuf/BoolValue.ts
export interface BoolValue {
  'value': (boolean);
}
```

This PR fixes this issue

