### PR TITLE
fix: Various type extractions

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -1023,6 +1023,23 @@ describe("generateZodSchema", () => {
     `);
   });
 
+  it("should handle parenthesis type nodes", () => {
+    const source = `export interface A {
+      a: (number) | string | null;
+      b: (string)
+      c: (number | string)
+    }
+    `;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "export const aSchema = z.object({
+          a: z.union([z.number(), z.string()]).nullable(),
+          b: z.string(),
+          c: z.union([z.number(), z.string()])
+      });"
+    `);
+  });
+
   it("should allow nullable on optional union properties", () => {
     const source = `export interface A {
       a?: number | string | null;

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -141,6 +141,54 @@ describe("traverseTypes", () => {
       const result = extractNames(source);
       expect(result).toEqual(["Person", "SuperHero", "Villain"]);
     });
+
+    it("should extract type from type alias", () => {
+      const source = `
+        export type Person = SuperHero `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "SuperHero"]);
+    });
+
+    it("should extract type from type alias with union", () => {
+      const source = `
+        export type Person = Villain | SuperHero `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain", "SuperHero"]);
+    });
+
+    it("should extract type from type alias with array", () => {
+      const source = `
+        export type Person = Villain[] `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain"]);
+    });
+
+    it("should extract type from type alias with parenthesis", () => {
+      const source = `
+        export type Person = (Villain) `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain"]);
+    });
+
+    it("should extract type from type alias with object literal", () => {
+      const source = `
+        export type Person = { hero: SuperHero} `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "SuperHero"]);
+    });
+
+    it("should extract type from type alias with union & object literal", () => {
+      const source = `
+        export type Person = Villain | { hero: SuperHero} `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain", "SuperHero"]);
+    });
   });
 });
 

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -174,6 +174,14 @@ describe("traverseTypes", () => {
       expect(result).toEqual(["Person", "Villain"]);
     });
 
+    it("should extract type from type alias with parenthesis", () => {
+      const source = `
+        export type Person = (Villain | Hero)[]`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain", "Hero"]);
+    });
+
     it("should extract type from type alias with object literal", () => {
       const source = `
         export type Person = { hero: SuperHero } `;

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -119,6 +119,28 @@ describe("traverseTypes", () => {
       const result = extractNames(source);
       expect(result).toEqual(["Person", "SuperHero", "Villain"]);
     });
+
+    it("should extract types between parenthesis", () => {
+      const source = `
+        export interface Person {
+            id: number,
+            t: (SuperHero)
+        }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "SuperHero"]);
+    });
+
+    it("should extract union types between parenthesis", () => {
+      const source = `
+        export interface Person {
+            id: number,
+            t: (SuperHero | Villain)
+        }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "SuperHero", "Villain"]);
+    });
   });
 });
 

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -166,6 +166,62 @@ describe("traverseTypes", () => {
       expect(result).toEqual(["Person", "Villain"]);
     });
 
+    it("should extract type from type alias with Array helper", () => {
+      const source = `
+        export type Person = Array<Villain> `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain"]);
+    });
+
+    it("should extract type from type alias with Promise helper", () => {
+      const source = `
+        export type Person = Promise<Villain> `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain"]);
+    });
+
+    it("should extract type from type alias with Required helper", () => {
+      const source = `
+        export type Person = Required<Villain> `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain"]);
+    });
+
+    it("should extract type from type alias with Partial helper", () => {
+      const source = `
+        export type Person = Partial<Villain> `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain"]);
+    });
+
+    it("should extract type from type alias with Omit helper", () => {
+      const source = `
+        export type Person = Omit<Villain> `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain"]);
+    });
+
+    it("should extract type from type alias with Pick helper", () => {
+      const source = `
+        export type Person = Pick<Villain> `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain"]);
+    });
+
+    it("should extract type from type alias with Record helper", () => {
+      const source = `
+        export type Person = Record<string, Villain> `;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Person", "Villain"]);
+    });
+
     it("should extract type from type alias with parenthesis", () => {
       const source = `
         export type Person = (Villain) `;

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -176,7 +176,7 @@ describe("traverseTypes", () => {
 
     it("should extract type from type alias with object literal", () => {
       const source = `
-        export type Person = { hero: SuperHero} `;
+        export type Person = { hero: SuperHero } `;
 
       const result = extractNames(source);
       expect(result).toEqual(["Person", "SuperHero"]);
@@ -184,7 +184,7 @@ describe("traverseTypes", () => {
 
     it("should extract type from type alias with union & object literal", () => {
       const source = `
-        export type Person = Villain | { hero: SuperHero} `;
+        export type Person = Villain | { hero: SuperHero } `;
 
       const result = extractNames(source);
       expect(result).toEqual(["Person", "Villain", "SuperHero"]);

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -40,11 +40,8 @@ export function getExtractedTypeNames(
 
     if (ts.isTypeReferenceNode(typeNode)) {
       referenceTypeNames.add(typeNode.getText(sourceFile));
-    } else if (
-      ts.isArrayTypeNode(typeNode) &&
-      ts.isTypeNode(typeNode.elementType)
-    ) {
-      referenceTypeNames.add(typeNode.elementType.getText(sourceFile));
+    } else if (ts.isArrayTypeNode(typeNode)) {
+      handleTypeNode(typeNode.elementType);
     } else if (ts.isTypeLiteralNode(typeNode)) {
       typeNode.forEachChild(visitorExtract);
     } else if (

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -40,20 +40,26 @@ export function getExtractedTypeNames(
     }
 
     if (childNode.type) {
-      if (ts.isTypeReferenceNode(childNode.type)) {
-        referenceTypeNames.add(childNode.type.getText(sourceFile));
+      let typeNode = childNode.type;
+
+      if (ts.isParenthesizedTypeNode(childNode.type)) {
+        typeNode = childNode.type.type;
+      }
+
+      if (ts.isTypeReferenceNode(typeNode)) {
+        referenceTypeNames.add(typeNode.getText(sourceFile));
       } else if (
-        ts.isArrayTypeNode(childNode.type) &&
-        ts.isTypeNode(childNode.type.elementType)
+        ts.isArrayTypeNode(typeNode) &&
+        ts.isTypeNode(typeNode.elementType)
       ) {
-        referenceTypeNames.add(childNode.type.elementType.getText(sourceFile));
-      } else if (ts.isTypeLiteralNode(childNode.type)) {
-        childNode.type.forEachChild(visitorExtract);
+        referenceTypeNames.add(typeNode.elementType.getText(sourceFile));
+      } else if (ts.isTypeLiteralNode(typeNode)) {
+        typeNode.forEachChild(visitorExtract);
       } else if (
-        ts.isIntersectionTypeNode(childNode.type) ||
-        ts.isUnionTypeNode(childNode.type)
+        ts.isIntersectionTypeNode(typeNode) ||
+        ts.isUnionTypeNode(typeNode)
       ) {
-        childNode.type.types.forEach((typeNode: ts.TypeNode) => {
+        typeNode.types.forEach((typeNode: ts.TypeNode) => {
           if (ts.isTypeReferenceNode(typeNode)) {
             referenceTypeNames.add(typeNode.getText(sourceFile));
           } else typeNode.forEachChild(visitorExtract);


### PR DESCRIPTION
# Why

Various expressions where not taken into account when extracting types, thus leading to missing schema in output generation.

The two latter ones were implemented in https://github.com/fabien0102/ts-to-zod/pull/152 and https://github.com/fabien0102/ts-to-zod/pull/155 which I close to merge all fixes in this PR. 

## Support of TypeScript Helpers

The following helpers were not handled well: `["Array", "Promise",  "Omit", "Pick", "Record", "Partial", "Required"]`
when used in expressions such as 
```ts
export type Person = Partial<Villain>
```

## Add support for ParenthesisTypeNodes
This was added in https://github.com/fabien0102/ts-to-zod/pull/152 (closed) following this comment: https://github.com/fabien0102/ts-to-zod/pull/148#issuecomment-1664231249

## Type identifiers not extracted from type alias declaration
This was added in https://github.com/fabien0102/ts-to-zod/pull/155 (closed)

Extracting types from expression such as 
```ts
export type Person = SuperHero
```
was not working
