### PR TITLE
fix mismatch between config file and `generate` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,11 @@ export interface Superman {
 
 ### Custom JSDoc Format Types
 
-`ts-to-zod` already supports converting several `@format` types such as `email` and `ip` to built-in Zod string validation functions. However, the types supported out of the box are only a subset of those recognized by the OpenAPI specification, which doesn't fit every use case. Thus, you can use the config file to define additional format types using the `customJSDocFormats` property like so:
+`ts-to-zod` already supports converting several `@format` types such as `email` and `ip` to built-in Zod string validation functions. However, the types supported out of the box are only a subset of those recognized by the OpenAPI specification, which doesn't fit every use case. Thus, you can use the config file to define additional format types using the `customJSDocFormatTypes` property like so:
 
 ```ts
 {
-  "customJSDocFormats": {
+  "customJSDocFormatTypes": {
     [formatTypeNoSpaces]:
       | string
       | {regex: string, errorMessage: string}
@@ -223,7 +223,7 @@ Here is an example configuration:
 
 ```json
 {
-  "customJSDocFormats": {
+  "customJSDocFormatTypes": {
     "phone-number": "^\\d{3}-\\d{3}-\\d{4}$",
     "date": {
       "regex": "^\\d{4}-\\d{2}-\\d{2}$",

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,7 +99,7 @@ export type Config = {
   /**
    * A record of custom `@format` types with their corresponding regex patterns.
    */
-  customJSDocFormats?: CustomJSDocFormatTypes;
+  customJSDocFormatTypes?: CustomJSDocFormatTypes;
 };
 
 export type Configs = Array<

--- a/src/config.zod.ts
+++ b/src/config.zod.ts
@@ -26,7 +26,10 @@ export const customJSDocFormatTypeAttributesSchema = z.object({
   errorMessage: z.string().optional(),
 });
 
+export const customJSDocFormatTypeSchema = z.string();
+
 export const customJSDocFormatTypesSchema = z.record(
+  customJSDocFormatTypeSchema,
   z.union([z.string(), customJSDocFormatTypeAttributesSchema])
 );
 
@@ -40,7 +43,7 @@ export const configSchema = z.object({
   keepComments: z.boolean().optional().default(false),
   skipParseJSDoc: z.boolean().optional().default(false),
   inferredTypes: z.string().optional(),
-  customJSDocFormats: customJSDocFormatTypesSchema.optional(),
+  customJSDocFormatTypes: customJSDocFormatTypesSchema.optional(),
 });
 
 export const configsSchema = z.array(

--- a/ts-to-zod.config.js
+++ b/ts-to-zod.config.js
@@ -9,7 +9,7 @@ module.exports = [
     input: "example/heros.ts",
     output: "example/heros.zod.ts",
     inferredTypes: "example/heros.types.ts",
-    customJSDocFormats: {
+    customJSDocFormatTypes: {
       date: {
         regex: "^\\d{4}-\\d{2}-\\d{2}$",
         errorMessage: "Must be in YYYY-MM-DD format.",


### PR DESCRIPTION
config file had property `customJSDocFormats` while `generate` expected `customJSDocFormatTypes`