### PR TITLE
core: upgrade to prettier v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",
     "ora": "^5.4.0",
-    "prettier": "2.2.1",
+    "prettier": "3.0.3",
     "rxjs": "^7.4.0",
     "slash": "^3.0.0",
     "threads": "^1.7.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -308,7 +308,7 @@ See more help with --help`,
       );
       await outputFile(
         generateOptions.inferredTypes,
-        prettier.format(
+        await prettier.format(
           hasExtensions(generateOptions.inferredTypes, javascriptExtensions)
             ? ts.transpileModule(zodInferredTypesFile, {
                 compilerOptions: {
@@ -326,7 +326,7 @@ See more help with --help`,
     if (output && hasExtensions(output, javascriptExtensions)) {
       await outputFile(
         outputPath,
-        prettier.format(
+        await prettier.format(
           ts.transpileModule(zodSchemasFile, {
             compilerOptions: {
               target: ts.ScriptTarget.Latest,
@@ -340,7 +340,7 @@ See more help with --help`,
     } else {
       await outputFile(
         outputPath,
-        prettier.format(zodSchemasFile, {
+        await prettier.format(zodSchemasFile, {
           parser: "babel-ts",
           ...prettierConfig,
         })

--- a/src/createConfig.ts
+++ b/src/createConfig.ts
@@ -162,7 +162,7 @@ module.exports = `;
     const prettierConfig = await prettier.resolveConfig(process.cwd());
     await outputFile(
       configPath,
-      prettier.format(header + JSON.stringify(answers.config), {
+      await prettier.format(header + JSON.stringify(answers.config), {
         parser: "babel",
         ...prettierConfig,
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4673,10 +4673,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
prettier API is now async
see https://github.com/prettier/prettier/wiki/How-to-migrate-my-plugin-to-support-Prettier-v3%3F#4-await-your-prettier-api-calls
