### PR TITLE
[Fix] Handle ExpressionWithTypeArguments in extend clause

### DIFF
--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -63,6 +63,36 @@ describe("traverseTypes", () => {
       expect(result).toEqual(["Superhero", "Person", "Person2"]);
     });
 
+    it("should extract type referenced in extend clause with Pick helper", () => {
+      const source = `
+            export interface Superhero extends Pick<Person, "name"> {
+                id: number,
+            }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Superhero", "Person"]);
+    });
+
+    it("should extract type referenced in extend clause with Record helper", () => {
+      const source = `
+            export interface Superhero extends Record<Person, Person2> {
+                id: number,
+            }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Superhero", "Person", "Person2"]);
+    });
+
+    it("should extract type referenced in extend clause with ExpressionWithTypeArguments", () => {
+      const source = `
+            export interface Superhero extends Person<Name, Person2> {
+                id: number,
+            }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Superhero", "Name", "Person2", "Person"]);
+    });
+
     it("should extract type referenced in property as array", () => {
       const source = `
             export interface Superhero {

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -75,22 +75,12 @@ describe("traverseTypes", () => {
 
     it("should extract type referenced in extend clause with Record helper", () => {
       const source = `
-            export interface Superhero extends Record<Person, Person2> {
+            export interface Superhero extends Record<string, Person2> {
                 id: number,
             }`;
 
       const result = extractNames(source);
-      expect(result).toEqual(["Superhero", "Person", "Person2"]);
-    });
-
-    it("should extract type referenced in extend clause with ExpressionWithTypeArguments", () => {
-      const source = `
-            export interface Superhero extends Person<Name, Person2> {
-                id: number,
-            }`;
-
-      const result = extractNames(source);
-      expect(result).toEqual(["Superhero", "Name", "Person2", "Person"]);
+      expect(result).toEqual(["Superhero", "Person2"]);
     });
 
     it("should extract type referenced in property as array", () => {

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -73,6 +73,27 @@ describe("traverseTypes", () => {
       expect(result).toEqual(["Superhero", "Person"]);
     });
 
+
+    it("should extract type referenced in extend clause with Omit helper", () => {
+      const source = `
+            export interface Superhero extends Omit<Person, "name"> {
+                id: number,
+            }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Superhero", "Person"]);
+    });
+
+    it("should extract type referenced in extend clause with Partial helper", () => {
+      const source = `
+            export interface Superhero extends Partial<Person, "name"> {
+                id: number,
+            }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual(["Superhero", "Person"]);
+    });
+
     it("should extract type referenced in extend clause with Record helper", () => {
       const source = `
             export interface Superhero extends Record<string, Person2> {

--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -73,7 +73,6 @@ describe("traverseTypes", () => {
       expect(result).toEqual(["Superhero", "Person"]);
     });
 
-
     it("should extract type referenced in extend clause with Omit helper", () => {
       const source = `
             export interface Superhero extends Omit<Person, "name"> {

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -84,7 +84,13 @@ export function getExtractedTypeNames(
         extensionTypes.forEach((extensionTypeNode) => {
           const typeName = extensionTypeNode.expression.getText(sourceFile);
 
-          referenceTypeNames.add(typeName);
+          if (extensionTypeNode.typeArguments) {
+            extensionTypeNode.typeArguments.forEach((t) => handleTypeNode(t));
+          }
+
+          if (typeScriptHelper.indexOf(typeName) === -1) {
+            referenceTypeNames.add(typeName);
+          }
         });
       });
     }


### PR DESCRIPTION
# Why

Type identifiers in extension clauses such as 
```ts
export interface Superhero extends Pick<Person, "name"> {
  id: number,
};
```
were not extracted correctly thus leading to incomplete generations.