### PR TITLE
fix: can't run command when the parent directory of `PWD` which exists `tsconfig.json`

### DIFF
--- a/.ts-to-zod_project_tag
+++ b/.ts-to-zod_project_tag
@@ -1,0 +1,1 @@
+This is an empty file used to mark the directory as the current project.

--- a/bin/run
+++ b/bin/run
@@ -2,8 +2,10 @@
 
 const fs = require("fs");
 const path = require("path");
-const project = path.join(__dirname, "../.ts-to-zod_project_tag");
-const dev = fs.existsSync(project);
+const project = path.join(__dirname, "../tsconfig.json");
+const dev = fs.existsSync(
+  path.join(__dirname, "../.ts-to-zod_project_tag")
+);
 
 if (dev) {
   require("ts-node").register({ project });

--- a/bin/run
+++ b/bin/run
@@ -2,7 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const project = path.join(__dirname, "../tsconfig.json");
+const project = path.join(__dirname, "../.ts-to-zod_project_tag");
 const dev = fs.existsSync(project);
 
 if (dev) {


### PR DESCRIPTION
# Why

I can't run command when the parent directory of `PWD` which exists `tsconfig.json`
