### PR TITLE
feat: add null handling for @default tag

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -1300,6 +1300,39 @@ describe("generateZodSchema", () => {
     `);
   });
 
+  it("should deal with @default null value", () => {
+    const source = `export interface WithDefaults {
+      /**
+       * @default null
+       */
+      nonNullableString: string;
+      /**
+       * @default null
+       */
+      nullableString: string | null;
+      /**
+       * @default "null"
+       */
+      nonNullableStringWithStringAsDefault: string;
+   }`;
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "export const withDefaultsSchema = z.object({
+          /**
+           * @default null
+           */
+          nonNullableString: z.string().nullable().default(null),
+          /**
+           * @default null
+           */
+          nullableString: z.string().nullable().default(null),
+          /**
+           * @default "null"
+           */
+          nonNullableStringWithStringAsDefault: z.string().default("null")
+      });"
+    `);
+  });
+
   it("should ignore unknown/broken jsdoc format", () => {
     const source = `export interface Hero {
      /**


### PR DESCRIPTION
# Why

Implementing a solution to https://github.com/fabien0102/ts-to-zod/issues/188
This adds `nullable` to the modifiers when the property if the `@default` is `null`