### PR TITLE
Parenthesized or null

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -626,7 +626,7 @@ describe("generateZodSchema", () => {
     );
   });
 
-  it("should deal with joined parenthesized type or null", () => {
+  it("should deal with joined schema parenthesized type or null", () => {
     const source = `export type person = (NormalGuy & BadGuy & randomGuy) | null;`;
     expect(generate(source)).toMatchInlineSnapshot(
       `"export const personSchema = normalGuySchema.and(badGuySchema).and(randomGuySchema).nullable();"`

--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -605,10 +605,31 @@ describe("generateZodSchema", () => {
     );
   });
 
-  it("should deal with parenthesized type", () => {
+  it("should deal with parenthesized schema type", () => {
     const source = `export type SecretVillain = (NormalGuy | Villain);`;
     expect(generate(source)).toMatchInlineSnapshot(
       `"export const secretVillainSchema = z.union([normalGuySchema, villainSchema]);"`
+    );
+  });
+
+  it("should deal with parenthesized type or null", () => {
+    const source = `export type SecretVillain = (NormalGuy | Villain) | null;`;
+    expect(generate(source)).toMatchInlineSnapshot(
+      `"export const secretVillainSchema = z.union([normalGuySchema, villainSchema]).nullable();"`
+    );
+  });
+
+  it("should deal with literal parenthesized type or null", () => {
+    const source = `export type Example = ("A" | "B") | null;`;
+    expect(generate(source)).toMatchInlineSnapshot(
+      `"export const exampleSchema = z.union([z.literal("A"), z.literal("B")]).nullable();"`
+    );
+  });
+
+  it("should deal with joined parenthesized type or null", () => {
+    const source = `export type person = (NormalGuy & BadGuy & randomGuy) | null;`;
+    expect(generate(source)).toMatchInlineSnapshot(
+      `"export const personSchema = normalGuySchema.and(badGuySchema).and(randomGuySchema).nullable();"`
     );
   });
 

--- a/src/core/generateZodSchema.ts
+++ b/src/core/generateZodSchema.ts
@@ -269,6 +269,7 @@ function buildZodPrimitive({
     return buildZodPrimitive({
       z,
       typeNode: typeNode.type,
+      isNullable,
       isOptional,
       jsDocTags,
       customJSDocFormatTypes,
@@ -744,7 +745,7 @@ function buildZodPrimitive({
       customJSDocFormatTypes,
     });
 
-    return rest.reduce(
+    const zodCall = rest.reduce(
       (intersectionSchema, node) =>
         f.createCallExpression(
           f.createPropertyAccessExpression(
@@ -768,6 +769,8 @@ function buildZodPrimitive({
         ),
       basePrimitive
     );
+
+    return withZodProperties(zodCall, zodProperties);
   }
 
   if (ts.isLiteralTypeNode(typeNode)) {


### PR DESCRIPTION
# Why
Parenthesized or null is a valid TS types, but the current generator does not recognized this.

<!-- Why did you make this PR? What problem does it solve? -->
Fix #197 