### PR TITLE
fix: context binding while processing errors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -295,7 +295,7 @@ See more help with --help`,
       };
     }
 
-    errors.map(this.warn);
+    errors.map(this.warn.bind(this));
 
     if (!Flags.skipValidation) {
       const validatorSpinner = ora("Validating generated types").start();


### PR DESCRIPTION
# Why

This PR fixes #185.

## How to reproduce

Input file:
```
export interface IHaveUnknownDependency {
  dep: UnknownDependency;
}
```

Actual output:
```
TypeError: Cannot read properties of undefined (reading 'jsonEnabled')
error Command failed with exit code 1.
```

Expected output:
```
 »   Warning: Some schemas can't be generated due to direct or indirect missing 
 »   dependencies:
 »   iHaveUnknownDependencySchema
✔ Validating generated types
🎉 Zod schemas generated!
```