### PR TITLE
Making --help flag work

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,6 +28,7 @@ jobs:
           architecture: ${{ matrix.architecture }}
       - run: yarn
       - run: chmod +x ./bin/run
+      - run: yarn build
       - run: yarn test:ci
       - run: yarn codecov
       - run: yarn lint

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,6 @@
+#!/usr/bin/env node_modules/.bin/ts-node
+
+(async () => {
+  const oclif = await import("@oclif/core");
+  await oclif.execute({ development: true, dir: __dirname });
+})();

--- a/bin/run
+++ b/bin/run
@@ -1,14 +1,6 @@
 #!/usr/bin/env node
 
-const fs = require("fs");
-const path = require("path");
-const project = path.join(__dirname, "../tsconfig.json");
-const dev = fs.existsSync(project);
-
-if (dev) {
-  require("ts-node").register({ project });
-}
-
-require(`../${dev ? "src/cli" : "lib/cli"}`)
-  .run()
-  .catch(require("@oclif/core/handle"));
+(async () => {
+  const oclif = await import("@oclif/core");
+  await oclif.execute({ development: false, dir: __dirname });
+})();

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@oclif/core": ">=3.10.8",
+    "@oclif/core": ">=3.26.0",
     "@typescript/vfs": "^1.5.0",
     "case": "^1.6.3",
     "chokidar": "^3.5.1",
@@ -90,6 +90,10 @@
     "trailingComma": "es5"
   },
   "oclif": {
-    "bin": "ts-to-zod"
+    "bin": "ts-to-zod",
+    "commands": {
+      "strategy": "single",
+      "target": "./lib/cli"
+    }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,6 +62,10 @@ try {
 class TsToZod extends Command {
   static description = "Generate Zod schemas from a Typescript file";
 
+  static examples: Command.Example[] = [
+    `$ ts-to-zod src/types.ts src/types.zod.ts`,
+  ];
+
   static usage = haveMultiConfig
     ? [
         "--all",

--- a/src/core/generate.test.ts
+++ b/src/core/generate.test.ts
@@ -221,7 +221,6 @@ describe("generate", () => {
       `);
       });
 
-      console.log(errors);
       it("should not have any errors", () => {
         expect(errors.length).toBe(0);
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,17 +1654,19 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@oclif/core@>=3.10.8":
-  version "3.10.8"
-  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.10.8.tgz#8a855841107576b88a2ebe2e20e6e0d7ee885713"
-  integrity sha512-DRiEiXUvijq/1dXL80/sFGdhTjejFiUzxURW7N310TEKlONujas66KhLATfF/nG3mICqTCU0f9B+VNfLtZoGqw==
+"@oclif/core@>=3.26.0":
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.26.0.tgz#959d5e9f13f4ad6a4e98235ad125189df9ee4279"
+  integrity sha512-TpMdfD4tfA2tVVbd4l0PrP02o5KoUXYmudBbTC7CeguDo/GLoprw4uL8cMsaVA26+cbcy7WYtOEydQiHVtJixA==
   dependencies:
+    "@types/cli-progress" "^3.11.5"
     ansi-escapes "^4.3.2"
     ansi-styles "^4.3.0"
     cardinal "^2.1.1"
     chalk "^4.1.2"
     clean-stack "^3.0.1"
     cli-progress "^3.12.0"
+    color "^4.2.3"
     debug "^4.3.4"
     ejs "^3.1.9"
     get-package-type "^0.1.0"
@@ -1673,15 +1675,15 @@
     indent-string "^4.0.0"
     is-wsl "^2.2.0"
     js-yaml "^3.14.1"
+    minimatch "^9.0.3"
     natural-orderby "^2.0.3"
     object-treeify "^1.1.33"
-    password-prompt "^1.1.2"
+    password-prompt "^1.1.3"
     slice-ansi "^4.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
     supports-color "^8.1.1"
     supports-hyperlinks "^2.2.0"
-    tsconfck "^3.0.0"
     widest-line "^3.1.0"
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
@@ -1779,6 +1781,13 @@
   integrity sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/cli-progress@^3.11.5":
+  version "3.11.5"
+  resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.11.5.tgz#9518c745e78557efda057e3f96a5990c717268c3"
+  integrity sha512-D4PbNRbviKyppS5ivBGyFO29POlySLmA2HyUFE4p5QGazAMM3CwkKWcvTl8gvElSuxRh6FPKL8XmidX873ou4g==
+  dependencies:
+    "@types/node" "*"
 
 "@types/fs-extra@^11.0.3":
   version "11.0.3"
@@ -2531,10 +2540,26 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 commander@^7.2.0:
   version "7.2.0"
@@ -3354,6 +3379,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
@@ -4123,6 +4153,13 @@ minimatch@^9.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^9.0.3:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
+  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
@@ -4358,7 +4395,7 @@ parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-password-prompt@^1.1.2:
+password-prompt@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/password-prompt/-/password-prompt-1.1.3.tgz#05e539f4e7ca4d6c865d479313f10eb9db63ee5f"
   integrity sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==
@@ -4742,6 +4779,13 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -5034,11 +5078,6 @@ ts-node@^10.9.1:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
-
-tsconfck@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.0.0.tgz#b469f1ced12973bbec3209a55ed8de3bb04223c9"
-  integrity sha512-w3wnsIrJNi7avf4Zb0VjOoodoO0woEqGgZGQm+LHH9przdUI+XDKsWAXwxHA1DaRTjeuZNcregSzr7RaA8zG9A==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
# Why

As described in https://github.com/fabien0102/ts-to-zod/issues/196, the `--help` flag didn't work anymore. 
Trying to add tests for `oclif`, I updated: 
- `@oclif/core` to latest (`3.26.0`)
- the `run` script, following the templates provided on oclif [website](https://oclif.io/docs/templates) (split into a `run` and `dev` ones)
- adding the `strategy` as `single` command for oclif ([documentation](https://oclif.io/docs/single_command_cli))

# Result

Running `ts-to-zod --help` will output the help information:

```
Generate Zod schemas from a Typescript file

USAGE
  $ ts-to-zod  --all
  $ ts-to-zod  --config example
  $ ts-to-zod  --config example/person
  $ ts-to-zod  --config config

ARGUMENTS
  INPUT   input file (typescript)
  OUTPUT  output file (zod schemas)

FLAGS
  -a, --all                    Execute all configs
  -c, --config=<option>        Execute one config
                               <options: example|example/person|config>
  -h, --help                   Show CLI help.
  -i, --init                   Create a ts-to-zod.config.js file
  -k, --keepComments           Keep parameters comments
  -v, --version                Show CLI version.
  -w, --watch                  Watch input file(s) for changes and re-run related task
      --inferredTypes=<value>  Path of z.infer<> types file
      --skipParseJSDoc         Skip the creation of zod validators from JSDoc annotations
      --skipValidation         Skip the validation step (not recommended)

DESCRIPTION
  Generate Zod schemas from a Typescript file

EXAMPLES
  $ ts-to-zod src/types.ts src/types.zod.ts
```

# Tests

Tested locally on the project I use `ts-to-zod` and it does seem to work. 
Still trying to get `@oclif/test` to work but I believe we can merge this still

