### PR TITLE
fix: release process needs build before publish

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -20,9 +20,11 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
         if: ${{ steps.release.outputs.release_created }}
       - run: yarn
+        if: ${{ steps.release.outputs.release_created }}
+      - run: yarn build
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         env:


### PR DESCRIPTION
Adding `yarn build` as a step of the release process  because of the update of the `./bin/run.js` script
