### PR TITLE
fix trivial typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ export const heroSchema = z.object({
 
 ### Non-Zod imports
 
-`ts-to-zod` can reference imported types from other modules but will use an `any` validation as placeholder, as we cannot now
+`ts-to-zod` can reference imported types from other modules but will use an `any` validation as placeholder, as we cannot know
 their schema.
 
 ```ts


### PR DESCRIPTION
# Why

It fixes a trivial typo in README.md that I saw when reading it.
