### PR TITLE
fix: .partial() must be applied before .nullable() or .optional()

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -1263,7 +1263,21 @@ describe("generateZodSchema", () => {
       "export const exampleSchema = z.object({
           field: z.object({
               foo: z.string()
-          }).nullable().partial()
+          }).partial().nullable()
+      });"
+    `);
+  });
+
+  it("should deal with optional partial", () => {
+    const source = `export type Example = {
+        field?: Partial<{foo: string}>
+    }`;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "export const exampleSchema = z.object({
+          field: z.object({
+              foo: z.string()
+          }).partial().optional()
       });"
     `);
   });

--- a/src/core/jsDocTags.ts
+++ b/src/core/jsDocTags.ts
@@ -301,6 +301,12 @@ export function jsDocTagToZodProperties(
   if (jsDocTags.strict) {
     zodProperties.push({ identifier: "strict" });
   }
+  // partial() must be before optional() and nullable()
+  if (isPartial) {
+    zodProperties.push({
+      identifier: "partial",
+    });
+  }
   if (isOptional) {
     zodProperties.push({
       identifier: "optional",
@@ -309,11 +315,6 @@ export function jsDocTagToZodProperties(
   if (isNullable || jsDocTags.default === null) {
     zodProperties.push({
       identifier: "nullable",
-    });
-  }
-  if (isPartial) {
-    zodProperties.push({
-      identifier: "partial",
     });
   }
   if (isRequired) {


### PR DESCRIPTION
# Why

Zod API requires that `.partial()` be applied to an object type _before_ `.nullable()` or `.optional()`.
