### PR TITLE
FIX: handle negative minimum, maximum, and default values from jsDoc

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -776,6 +776,13 @@ describe("generateZodSchema", () => {
        * @maxLength 123
        */
       blockedPhoneNumbers: string[];
+
+      /**
+       * The angle of the hero's raised or furrowed eyebrow.
+       *
+       * @minimum -45 @maximum -5 @default -20
+       */
+      eyebrowAngle: number;
     }`;
     expect(generate(source)).toMatchInlineSnapshot(`
       "export const heroContactSchema = z.object({
@@ -858,7 +865,13 @@ describe("generateZodSchema", () => {
            * @minLength 56
            * @maxLength 123
            */
-          blockedPhoneNumbers: z.array(z.string().regex(/^([+]?d{1,2}[-s]?|)d{3}[-s]?d{3}[-s]?d{4}$/)).min(56).max(123)
+          blockedPhoneNumbers: z.array(z.string().regex(/^([+]?d{1,2}[-s]?|)d{3}[-s]?d{3}[-s]?d{4}$/)).min(56).max(123),
+          /**
+           * The angle of the hero's raised or furrowed eyebrow.
+           *
+           * @minimum -45 @maximum -5 @default -20
+           */
+          eyebrowAngle: z.number().min(-45).max(-5).default(-20)
       });"
     `);
   });

--- a/src/core/jsDocTags.ts
+++ b/src/core/jsDocTags.ts
@@ -250,7 +250,12 @@ export function jsDocTagToZodProperties(
     zodProperties.push({
       identifier: "min",
       expressions: withErrorMessage(
-        f.createNumericLiteral(jsDocTags.minimum.value),
+        jsDocTags.minimum.value < 0
+          ? f.createPrefixUnaryExpression(
+              ts.SyntaxKind.MinusToken,
+              f.createNumericLiteral(Math.abs(jsDocTags.minimum.value))
+            )
+          : f.createNumericLiteral(jsDocTags.minimum.value),
         jsDocTags.minimum.errorMessage
       ),
     });
@@ -259,7 +264,12 @@ export function jsDocTagToZodProperties(
     zodProperties.push({
       identifier: "max",
       expressions: withErrorMessage(
-        f.createNumericLiteral(jsDocTags.maximum.value),
+        jsDocTags.maximum.value < 0
+          ? f.createPrefixUnaryExpression(
+              ts.SyntaxKind.MinusToken,
+              f.createNumericLiteral(Math.abs(jsDocTags.maximum.value))
+            )
+          : f.createNumericLiteral(jsDocTags.maximum.value),
         jsDocTags.maximum.errorMessage
       ),
     });
@@ -338,7 +348,14 @@ export function jsDocTagToZodProperties(
           : jsDocTags.default === false
           ? [f.createFalse()]
           : typeof jsDocTags.default === "number"
-          ? [f.createNumericLiteral(jsDocTags.default)]
+          ? jsDocTags.default < 0
+            ? [
+                f.createPrefixUnaryExpression(
+                  ts.SyntaxKind.MinusToken,
+                  f.createNumericLiteral(Math.abs(jsDocTags.default))
+                ),
+              ]
+            : [f.createNumericLiteral(jsDocTags.default)]
           : jsDocTags.default === null
           ? [f.createNull()]
           : [f.createStringLiteral(jsDocTags.default)],


### PR DESCRIPTION
Closes fabien0102/ts-to-zod#227 (or would if it wasn't already closed for inactivity)

# Why

Linked issue isn't mine, but I experienced (almost) the same thing. I have an interface that has a negative `minimum` value in the jsDoc

```ts
  /**
   * @minimum -45 @maximum 45
   */
  angle: number | null
```

Which results in the error:
```
Error: Debug Failure. False expression: Negative numbers should be created in combination with createPrefixUnaryExpression
```

This PR prevents the error and adds a check a couple of the existing tests