### PR TITLE
chore: add missing local development build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ To learn more about those functions or their usages, `src/core/generate.ts` is a
 $ git clone
 $ cd ts-to-zod
 $ yarn
+$ yarn build
 $ ./bin/run
 USAGE
   $ ts-to-zod [input] [output]


### PR DESCRIPTION
# Why
Just something I noticed while working on https://github.com/fabien0102/ts-to-zod/pull/250, there was an extra step needed before I could execute `./bin/run` without error.
