### PR TITLE
ci(codecov): update codecov command

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,5 +30,5 @@ jobs:
       - run: chmod +x ./bin/run
       - run: yarn build
       - run: yarn test:ci
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
       - run: yarn lint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,5 +30,5 @@ jobs:
       - run: chmod +x ./bin/run
       - run: yarn build
       - run: yarn test:ci
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v3
       - run: yarn lint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,5 +30,5 @@ jobs:
       - run: chmod +x ./bin/run
       - run: yarn build
       - run: yarn test:ci
-      - run: yarn codecov
+      - uses: codecov/codecov-action@v4
       - run: yarn lint


### PR DESCRIPTION
# Why

Last PR, the `yarn codecov` step failed (also on my local machine). 

The current version we use (3.8.3) has been deprecated (see [the repo](https://github.com/codecov/codecov-node))

The goto method seems to use Github Action now ([Documentation](https://github.com/codecov/codecov-action?tab=readme-ov-file#breaking-changes))