### PR TITLE
feat: add support for discriminatedUnion

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,5 +30,4 @@ jobs:
       - run: chmod +x ./bin/run
       - run: yarn build
       - run: yarn test:ci
-      - run: yarn codecov
       - run: yarn lint

--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -1620,15 +1620,6 @@ describe("generateZodSchema", () => {
     `);
   });
 
-  it("should throw on generics", () => {
-    const source = `export interface Villain<TPower> {
-     powers: TPower[]
-   }`;
-    expect(() => generate(source)).toThrowErrorMatchingInlineSnapshot(
-      `"Interface with generics are not supported!"`
-    );
-  });
-
   it("should throw on interface with generics", () => {
     const source = `export interface Villain<TPower> {
      powers: TPower[]

--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -1492,6 +1492,83 @@ describe("generateZodSchema", () => {
     `);
   });
 
+  it("should generate a discriminatedUnion when @discriminator is used", () => {
+    const source = `
+    /**
+     * @discriminator id
+     **/
+    export type A = { id: "1"; name: string; } | { id: "2"; age: number; }`;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "/**
+       * @discriminator id
+       **/
+      export const aSchema = z.discriminatedUnion("id", [z.object({
+              id: z.literal("1"),
+              name: z.string()
+          }), z.object({
+              id: z.literal("2"),
+              age: z.number()
+          })]);"
+    `);
+  });
+
+  it("should generate a discriminatedUnion with a referenced type", () => {
+    const source = `
+    /**
+     * @discriminator id
+     **/
+    export type Foo = { id: "1"; name: string; } | Bar`;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "/**
+       * @discriminator id
+       **/
+      export const fooSchema = z.discriminatedUnion("id", [z.object({
+              id: z.literal("1"),
+              name: z.string()
+          }), barSchema]);"
+    `);
+  });
+
+  it("should fall back to union when types are not discriminated", () => {
+    const source = `
+    /**
+     * @discriminator id
+     **/
+    export type A = { id: "1"; name: string; } | string`;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "/**
+       * @discriminator id
+       **/
+      export const aSchema = z.union([z.object({
+              id: z.literal("1"),
+              name: z.string()
+          }), z.string()]);"
+    `);
+  });
+
+  it("should fall back to union when discriminator is missing", () => {
+    const source = `
+    /**
+     * @discriminator id
+     **/
+    export type A = { name: string; } | { id: "2"; age: number; }`;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "/**
+       * @discriminator id
+       **/
+      export const aSchema = z.union([z.object({
+              name: z.string()
+          }), z.object({
+              id: z.literal("2"),
+              age: z.number()
+          })]);"
+    `);
+  });
+
   it("should deal with @default with all types", () => {
     const source = `export interface WithDefaults {
      /**

--- a/src/core/jsDocTags.ts
+++ b/src/core/jsDocTags.ts
@@ -69,6 +69,7 @@ export interface JSDocTagsBase {
   pattern?: string;
   strict?: boolean;
   schema?: string;
+  discriminator?: string;
 }
 
 export type ElementJSDocTags = Pick<
@@ -103,6 +104,7 @@ const jsDocTagKeys: Array<keyof JSDocTags> = [
   "elementMaxLength",
   "elementPattern",
   "elementFormat",
+  "discriminator",
 ];
 
 /**
@@ -214,6 +216,9 @@ export function getJSDocTags(nodeType: ts.Node, sourceFile: ts.SourceFile) {
               // string without quotes
               jsDocTags[tagName] = tag.comment;
             }
+            break;
+          case "discriminator":
+            jsDocTags[tagName] = tag.comment;
             break;
           case "strict":
             break;


### PR DESCRIPTION
# Why

Implement #270 
Introduces a new `@discriminator type` tag to set the union as a `z.discrimatedUnion(type, ...)`
