### PR TITLE
fix: correctly extract types from index signature declaration

### DIFF
--- a/src/utils/traverseTypes.test.ts
+++ b/src/utils/traverseTypes.test.ts
@@ -477,6 +477,18 @@ describe("traverseTypes", () => {
         { name: "Skill", partOfQualifiedName: false },
       ]);
     });
+
+    it("should extract type in index signature", () => {
+      const source = `export interface Hero {
+        powers: {[name: string] : Power}
+      }`;
+
+      const result = extractNames(source);
+      expect(result).toEqual([
+        { name: "Hero", partOfQualifiedName: false },
+        { name: "Power", partOfQualifiedName: false },
+      ]);
+    });
   });
 });
 

--- a/src/utils/traverseTypes.ts
+++ b/src/utils/traverseTypes.ts
@@ -38,13 +38,13 @@ export function getReferencedTypeNames(
   referenceTypeNames.add({ name: node.name.text, partOfQualifiedName: false });
 
   const visitorExtract = (child: ts.Node) => {
-    if (!ts.isPropertySignature(child)) {
-      return;
-    }
-
-    const childNode = child as ts.PropertySignature;
-    if (childNode.type) {
-      handleTypeNode(childNode.type);
+    if (ts.isPropertySignature(child)) {
+      const childNode = child as ts.PropertySignature;
+      if (childNode.type) {
+        handleTypeNode(childNode.type);
+      }
+    } else if (ts.isIndexSignatureDeclaration(child) && child.type) {
+      handleTypeNode(child.type);
     }
   };
 


### PR DESCRIPTION
# Why

Fixes #277 

