### PR TITLE
feat: Improve Object Type Handling in Zod Conversion

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -758,6 +758,13 @@ describe("generateZodSchema", () => {
     );
   });
 
+  it("should generate an object schema", () => {
+    const source = `export type Object = object;`;
+    expect(generate(source)).toMatchInlineSnapshot(
+      `"export const objectSchema = z.record(z.any());"`
+    );
+  });
+
   it("should generate custom validators based on jsdoc tags", () => {
     const source = `export interface HeroContact {
       /**

--- a/src/core/generateZodSchema.ts
+++ b/src/core/generateZodSchema.ts
@@ -1013,6 +1013,13 @@ function buildZodPrimitiveInternal({
       return buildZodSchema(z, "never", [], zodProperties);
     case ts.SyntaxKind.UnknownKeyword:
       return buildZodSchema(z, "unknown", [], zodProperties);
+    case ts.SyntaxKind.ObjectKeyword:
+      return buildZodSchema(
+        z,
+        "record",
+        [buildZodSchema(z, "any")],
+        zodProperties
+      );
   }
 
   if (ts.isTemplateLiteralTypeNode(typeNode)) {


### PR DESCRIPTION
# Why
- When defining an object type within an object, it is inferred as any when converted to Zod.
![image](https://github.com/user-attachments/assets/8ba954e9-91ce-4a68-b5e1-8d05239e593f)

- any is a supertype of object, necessitating a stronger assertion of the type.

- After generating the type, during validation, any includes optional, which leads to a mismatch with the original type.
![image](https://github.com/user-attachments/assets/7722eb35-4706-42c1-b630-04ab546138d3)

- This issue is resolved by treating the object as record any. => z.record(z.any())


# Result

case 1: primitive object
``` typescript
export type Obj = object;

```

``` typescript
// Generated by ts-to-zod
import { z } from "zod";

export const objSchema = z.record(z.any());


```

case 2: object in object
```typescript

export interface ExampleObject {
  result: object;
}
```

```typescript
// Generated by ts-to-zod
import { z } from "zod";

export const exampleObjectSchema = z.object({
  result: z.record(z.any()),
});

```


# Test
I added a test case related to this PR.

![image](https://github.com/user-attachments/assets/0d6d340f-c10e-4405-8d7c-77e9a42eb09f)
