### PR TITLE
chore: move vitest to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "tslib": "^2.3.1",
     "tsutils": "^3.21.0",
     "typescript": "^5.2.2",
-    "vitest": "^3.2.4",
     "zod": "^4.1.5"
   },
   "devDependencies": {
@@ -74,7 +73,8 @@
     "prettier": "3.6.2",
     "pretty-quick": "5.0.0-next.2",
     "rimraf": "^5.0.5",
-    "ts-node": "^10.9.1"
+    "ts-node": "^10.9.1",
+    "vitest": "^3.2.4"
   },
   "prettier": {
     "printWidth": 80,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,9 +37,6 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.9.2
-      vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.5.2)
       zod:
         specifier: ^4.1.5
         version: 4.1.11
@@ -104,6 +101,9 @@ importers:
       ts-node:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@24.5.2)(typescript@5.9.2)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.5.2)
 
 packages:
   "@ampproject/remapping@2.3.0":


### PR DESCRIPTION
# Why

This pull request makes a small housekeeping update by moving the vitest package from dependencies to devDependencies in both package.json and pnpm-lock.yaml.

This aligns the dependency setup with common best practices, ensuring that vitest is installed only in development environments.
No functional or runtime behavior is affected.