### PR TITLE
fix: Add support for additional numeric formats in JSDoc tags

### DIFF
--- a/src/core/generateZodSchema.ts
+++ b/src/core/generateZodSchema.ts
@@ -1134,26 +1134,6 @@ function buildZodPrimitiveInternal({
     case ts.SyntaxKind.AnyKeyword:
       return buildZodSchema(z, "any", [], zodProperties);
     case ts.SyntaxKind.BigIntKeyword:
-      // Check for bigint format in JSDoc tags and generate appropriate Zod v4 schema
-      if (jsDocTags.format) {
-        const formatValue = jsDocTags.format.value;
-        const bigintFormats = ["int64", "uint64"];
-
-        if (bigintFormats.includes(formatValue)) {
-          const nonFormatProperties = zodProperties.filter(
-            (prop) => prop.identifier !== formatValue
-          );
-          const formatArgs = jsDocTags.format.errorMessage
-            ? [f.createStringLiteral(jsDocTags.format.errorMessage)]
-            : [];
-          return buildZodSchema(
-            z,
-            formatValue,
-            formatArgs,
-            nonFormatProperties
-          );
-        }
-      }
       return buildZodSchema(z, "bigint", [], zodProperties);
     case ts.SyntaxKind.VoidKeyword:
       return buildZodSchema(z, "void", [], zodProperties);

--- a/src/core/generateZodSchema.ts
+++ b/src/core/generateZodSchema.ts
@@ -1105,7 +1105,15 @@ function buildZodPrimitiveInternal({
       // Check for numeric format in JSDoc tags and generate appropriate Zod v4 schema
       if (jsDocTags.format) {
         const formatValue = jsDocTags.format.value;
-        const numericFormats = ["int", "float32", "float64", "int32", "uint32"];
+        const numericFormats = [
+          "int",
+          "float32",
+          "float64",
+          "int32",
+          "uint32",
+          "int64",
+          "uint64",
+        ];
 
         if (numericFormats.includes(formatValue)) {
           const nonFormatProperties = zodProperties.filter(


### PR DESCRIPTION
Extend the supported numeric formats in JSDoc tags to include `int64` and `uint64`.

it seems case ts.SyntaxKind.NumberKeyword now includes `int64` and `uint64`.

this partially fixes #355 

this fixes the case

```ts
interface Body {
  /**
   * @format int64
   */
  id: number;
}

```
but doesn't fix the case

```ts
interface Body {
  /**
   * @format int64
   */
  id: string;
}
```