### PR TITLE
feat: Enhance JSDoc numeric format support and validation

### DIFF
--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -1955,6 +1955,135 @@ describe("generateZodSchema", () => {
     `
     );
   });
+
+  it("should generate string refine validation for numeric formats on string types", () => {
+    const source = `export interface NumericStringFormats {
+      /**
+       * @format int64
+       */
+      int64Value: string;
+
+      /**
+       * @format uint64
+       */
+      uint64Value: string;
+
+      /**
+       * @format int32
+       */
+      int32Value: string;
+
+      /**
+       * @format float32
+       */
+      float32Value: string;
+
+      /**
+       * @format int64 Custom error message
+       */
+      customErrorValue: string;
+    }`;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "export const numericStringFormatsSchema = z.object({
+          /**
+           * @format int64
+           */
+          int64Value: z.string().refine(val => { try {
+              z.int64().parse(BigInt(val));
+              return true;
+          }
+          catch {
+              return false;
+          } }, { message: "Must be a valid int64 string" }),
+          /**
+           * @format uint64
+           */
+          uint64Value: z.string().refine(val => { try {
+              z.uint64().parse(BigInt(val));
+              return true;
+          }
+          catch {
+              return false;
+          } }, { message: "Must be a valid uint64 string" }),
+          /**
+           * @format int32
+           */
+          int32Value: z.string().refine(val => { try {
+              z.int32().parse(Number(val));
+              return true;
+          }
+          catch {
+              return false;
+          } }, { message: "Must be a valid int32 string" }),
+          /**
+           * @format float32
+           */
+          float32Value: z.string().refine(val => { try {
+              z.float32().parse(Number(val));
+              return true;
+          }
+          catch {
+              return false;
+          } }, { message: "Must be a valid float32 string" }),
+          /**
+           * @format int64 Custom error message
+           */
+          customErrorValue: z.string().refine(val => { try {
+              z.int64().parse(BigInt(val));
+              return true;
+          }
+          catch {
+              return false;
+          } }, { message: "Custom error message" })
+      });"
+    `);
+  });
+
+  it("should generate direct numeric schemas for numeric formats on number types", () => {
+    const source = `export interface NumericFormats {
+      /**
+       * @format int64
+       */
+      int64Value: number;
+
+      /**
+       * @format uint64
+       */
+      uint64Value: number;
+
+      /**
+       * @format int32
+       */
+      int32Value: number;
+
+      /**
+       * @format float32
+       */
+      float32Value: number;
+    }`;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "export const numericFormatsSchema = z.object({
+          /**
+           * @format int64
+           */
+          int64Value: z.int64(),
+          /**
+           * @format uint64
+           */
+          uint64Value: z.uint64(),
+          /**
+           * @format int32
+           */
+          int32Value: z.int32(),
+          /**
+           * @format float32
+           */
+          float32Value: z.float32()
+      });"
+    `);
+  });
 });
 
 /**

--- a/src/core/generateZodSchema.test.ts
+++ b/src/core/generateZodSchema.test.ts
@@ -1982,6 +1982,11 @@ describe("generateZodSchema", () => {
        * @format int64 Custom error message
        */
       customErrorValue: string;
+
+      /**
+       * @format int32
+       */
+      optionalInt32?: string;
     }`;
 
     expect(generate(source)).toMatchInlineSnapshot(`
@@ -2035,7 +2040,17 @@ describe("generateZodSchema", () => {
           }
           catch {
               return false;
-          } }, { message: "Custom error message" })
+          } }, { message: "Custom error message" }),
+          /**
+           * @format int32
+           */
+          optionalInt32: z.string().refine(val => { try {
+              z.int32().parse(Number(val));
+              return true;
+          }
+          catch {
+              return false;
+          } }, { message: "Must be a valid int32 string" }).optional()
       });"
     `);
   });
@@ -2081,6 +2096,60 @@ describe("generateZodSchema", () => {
            * @format float32
            */
           float32Value: z.float32()
+      });"
+    `);
+  });
+
+  it("should handle optional and nullable properties with numeric formats on strings", () => {
+    const source = `export interface OptionalNumericStringFormats {
+      /**
+       * @format int64
+       */
+      optionalInt64?: string;
+
+      /**
+       * @format uint32
+       */
+      nullableUint32: string | null;
+
+      /**
+       * @format float32
+       */
+      optionalNullableFloat32?: string | null;
+    }`;
+
+    expect(generate(source)).toMatchInlineSnapshot(`
+      "export const optionalNumericStringFormatsSchema = z.object({
+          /**
+           * @format int64
+           */
+          optionalInt64: z.string().refine(val => { try {
+              z.int64().parse(BigInt(val));
+              return true;
+          }
+          catch {
+              return false;
+          } }, { message: "Must be a valid int64 string" }).optional(),
+          /**
+           * @format uint32
+           */
+          nullableUint32: z.string().refine(val => { try {
+              z.uint32().parse(Number(val));
+              return true;
+          }
+          catch {
+              return false;
+          } }, { message: "Must be a valid uint32 string" }).nullable(),
+          /**
+           * @format float32
+           */
+          optionalNullableFloat32: z.string().refine(val => { try {
+              z.float32().parse(Number(val));
+              return true;
+          }
+          catch {
+              return false;
+          } }, { message: "Must be a valid float32 string" }).optional().nullable()
       });"
     `);
   });

--- a/src/core/generateZodSchema.ts
+++ b/src/core/generateZodSchema.ts
@@ -1134,26 +1134,6 @@ function buildZodPrimitiveInternal({
     case ts.SyntaxKind.AnyKeyword:
       return buildZodSchema(z, "any", [], zodProperties);
     case ts.SyntaxKind.BigIntKeyword:
-      // Check for bigint format in JSDoc tags and generate appropriate Zod v4 schema
-      if (jsDocTags.format) {
-        const formatValue = jsDocTags.format.value;
-        const bigintFormats = ["int64", "uint64"];
-
-        if (bigintFormats.includes(formatValue)) {
-          const nonFormatProperties = zodProperties.filter(
-            (prop) => prop.identifier !== formatValue
-          );
-          const formatArgs = jsDocTags.format.errorMessage
-            ? [f.createStringLiteral(jsDocTags.format.errorMessage)]
-            : [];
-          return buildZodSchema(
-            z,
-            formatValue,
-            formatArgs,
-            nonFormatProperties
-          );
-        }
-      }
       return buildZodSchema(z, "bigint", [], zodProperties);
     case ts.SyntaxKind.VoidKeyword:
       return buildZodSchema(z, "void", [], zodProperties);

--- a/src/core/generateZodSchema.ts
+++ b/src/core/generateZodSchema.ts
@@ -1139,7 +1139,7 @@ function buildZodPrimitiveInternal({
           ]);
 
           const stringSchema = buildZodSchema(z, "string", [], []);
-          return f.createCallExpression(
+          const refineCall = f.createCallExpression(
             f.createPropertyAccessExpression(
               stringSchema,
               f.createIdentifier("refine")
@@ -1147,6 +1147,23 @@ function buildZodPrimitiveInternal({
             undefined,
             [refineFunction, refineOptions]
           );
+
+          // Filter out format-related properties since we're handling the format validation with refine
+          const nonFormatProperties = zodProperties.filter(
+            (prop) =>
+              ![
+                "int",
+                "int32",
+                "uint32",
+                "int64",
+                "uint64",
+                "float32",
+                "float64",
+              ].includes(prop.identifier)
+          );
+
+          // Apply zodProperties (like .optional(), .nullable(), etc.) to the refine call
+          return withZodProperties(refineCall, nonFormatProperties);
         }
 
         // Handle direct format validators (Zod v4 standalone methods)

--- a/src/core/generateZodSchema.ts
+++ b/src/core/generateZodSchema.ts
@@ -1105,7 +1105,15 @@ function buildZodPrimitiveInternal({
       // Check for numeric format in JSDoc tags and generate appropriate Zod v4 schema
       if (jsDocTags.format) {
         const formatValue = jsDocTags.format.value;
-        const numericFormats = ["int", "float32", "float64", "int32", "uint32"];
+        const numericFormats = [
+          "int",
+          "float32",
+          "float64",
+          "int32",
+          "uint32",
+          "int64",
+          "uint64",
+        ];
 
         if (numericFormats.includes(formatValue)) {
           const nonFormatProperties = zodProperties.filter(


### PR DESCRIPTION
Introduce support for additional numeric formats in JSDoc tags and implement custom validation for these formats in the `buildZodPrimitiveInternal` function.

Tests added.

this fixes the case for int64 and uint64 numbers and also fixes the validation for strings that represent numbers

closes #355 

this also covers #356 

this fixes `Property 'int64' does not exist on type 'ZodString'` by adding validation logic for ints.

```ts
export const bodySchema = z.object({
    id: z.string().int64(),
});
```

it can also be fixed by skipping int validation entirely for strings.

i think this behavior should be configurable? validating strings as valid numbers should be optional or not?