### PR TITLE
fix: robust reading of moduleResolution from tsconfig.json

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -198,9 +198,7 @@ class TsToZod extends Command {
       // fallback to check module as moduleResolution has the required default values for these modules
       explicitFileExtImports =
         ["node16", "nodenext"].includes(moduleResolution || "") ||
-        ["node16", "node18", "node20", "nodenext"].includes(
-          tsConfig.compilerOptions.module
-        );
+        ["node16", "node18", "node20", "nodenext"].includes(module || "");
     } catch (error) {
       this.log(
         `Unable to read tsconfig.json to determine moduleResolution: ${error}`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,22 +171,41 @@ class TsToZod extends Command {
     const fileConfig = await this.loadFileConfig(config, flags);
 
     // Read `tsconfig.json` to find `moduleResolution` value
+    const configFilename = "tsconfig.json";
     let explicitFileExtImports = false;
     try {
       const rawTsConfig = await readFile(
-        join(process.cwd(), "tsconfig.json"),
+        join(process.cwd(), configFilename),
         "utf-8"
       );
+      const parsedTsConfig = ts.parseConfigFileTextToJson(
+        configFilename,
+        rawTsConfig
+      );
+
       const tsConfigSchema = z.object({
         compilerOptions: z.object({
-          moduleResolution: z.string(),
+          module: z.string().optional(),
+          moduleResolution: z.string().optional(),
         }),
       });
-      const tsConfig = z.parse(tsConfigSchema, JSON.parse(rawTsConfig));
-      explicitFileExtImports = ["node16", "nodenext"].includes(
-        tsConfig.compilerOptions.moduleResolution
+      const tsConfig = z.parse(tsConfigSchema, parsedTsConfig.config);
+
+      const module = tsConfig.compilerOptions.module?.toLowerCase();
+      const moduleResolution =
+        tsConfig.compilerOptions.moduleResolution?.toLowerCase();
+
+      // fallback to check module as moduleResolution has the required default values for these modules
+      explicitFileExtImports =
+        ["node16", "nodenext"].includes(moduleResolution || "") ||
+        ["node16", "node18", "node20", "nodenext"].includes(
+          tsConfig.compilerOptions.module
+        );
+    } catch (error) {
+      this.log(
+        `Unable to read tsconfig.json to determine moduleResolution: ${error}`
       );
-    } catch {}
+    }
 
     const ioMappings = getInputOutputMappings(config);
     const tasks = new Listr<void>([]);


### PR DESCRIPTION
# Why

I came across the same issue reported in #358 - the imports generated as `from "./SchemaFile.zod"` instead of `from "./SchemaFile.zod.js"`.

Upon investigation, this is due to the parsing of the tsconfig.json file failing silently, due to it containing comments. I confirmed this by removing the comments from my tsconfig.json file and it found my moduleResolution setting.

Since comments are common in this file (they're even there when running `tsc --init`), there is a safe method for parsing the config file included: ts.parseConfigFileTextToJson .

I've made the parsing of the tsconfig.json more robust overall, to also handle the scenario where module or moduleResolution (or both!) are not included in the configuration, as neither field are required but have default values for different circumstances.

Fixes #358 